### PR TITLE
Fix name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ arXiv.
 ## Example call:
 
 ```
-python -m arxiv_latex_cleaner.arxiv_latex_cleaner /path/to/latex/ --im_size 500 --images_whitelist='{"images/im.png":2000}'
+python -m arxiv-latex-cleaner.arxiv_latex_cleaner /path/to/latex/ --im_size 500 --images_whitelist='{"images/im.png":2000}'
 ```
 
 ## Main features:


### PR DESCRIPTION
```
git clone git@github.com:google-research/arxiv-latex-cleaner.git

python -m arxiv_latex_cleaner.arxiv_latex_cleaner /path/to/latex/
/Users/nzw/.pyenv/versions/miniconda3-latest/bin/python: Error while finding module specification for 'arxiv_latex_cleaner.arxiv_latex_cleaner' (ModuleNotFoundError: No module named 'arxiv_latex_cleaner')
```