### PR TITLE
Fix issue #9 (commands inside commands)

### DIFF
--- a/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner.py
@@ -105,7 +105,7 @@ def _remove_command(text, command):
 def _remove_environment(text, environment):
   """Removes '\\begin{environment}*\\end{environment}' from 'text'."""
   return re.sub(
-      r'\\begin\{' + environment + r'\}[\s\S]*\\end\{' + environment + r'\}', '',
+      r'\\begin\{' + environment + r'\}[\s\S]*?\\end\{' + environment + r'\}', '',
       text)
 
 
@@ -117,7 +117,7 @@ def _remove_comments_inline(text):
     return ''
   match = re.search(r'(?<!\\)%', text)
   if match:
-    return text[:match.end()] + '\n'
+    return text[:match.end()-1] + '\n'
   else:
     return text
 

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -11,5 +11,7 @@ This is a percent \%.
 \includegraphics{images/im1_included.png}
 
 This is a todo command\mytodo{Do this later}
+\mytodo{This is a todo command with a nested \textit{command}.
+Please remember that up to \texttt{2 levels} of \textit{nesting} are supported.}
 
 \input{figures/figure_included.tex}

--- a/tex_arXiv_true/main.tex
+++ b/tex_arXiv_true/main.tex
@@ -8,4 +8,5 @@ This is a percent \%.
 
 This is a todo command
 
+
 \input{figures/figure_included.tex}


### PR DESCRIPTION
This PR introduces the possibility to delete user-defined custom commands that contain nested commands (e.g., `\textit{}`, `\texttt{}`) as reported in the issue #9.

I have improved the regex that matches the custom command as well as the one that matches the `\begin{}...\end{}` environment.

The only limitation is that a maximum of two nested levels is supported, which seems to be reasonable in most of the scenarios.