### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 absl_py~=0.6.1
 Pillow~=5.3.0
+setuptools~=41.0.1


### PR DESCRIPTION
I was installing arxiv-latex-cleaner in a vanilla notebook and received this error: "ImportError: No module named setuptools"

Updating the requirements to install setuptools fixed this.