### PR TITLE
Prevent ghostscript from auto-rotating pages

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -24,7 +24,8 @@ from PIL import Image
 PDF_RESIZE_COMMAND = (
     'gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dNOPAUSE -dQUIET -dBATCH '
     '-dDownsampleColorImages=true -dColorImageResolution={resolution} '
-    '-dColorImageDownsampleThreshold=1.0 -sOutputFile={output} {input}')
+    '-dColorImageDownsampleThreshold=1.0 -sOutputFile={output} {input} '
+    '-dAutoRotatePages=/None')
 MAX_FILENAME_LENGTH = 120
 
 # Fix for Windows: Even if '\' (os.sep) is the standard way of making paths on


### PR DESCRIPTION
In some cases, ghostscript will automatically rotate some pages in some PDF files. This becomes annoying when a PDF figure suddenly changes orientation in the paper. The flag `-dAutoRotatePages=/None` prevents this behavior so that the orientation is retained.