### PR TITLE
Feature/config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ arxiv_latex_cleaner /path/to/latex --config cleaner_config.yaml
 pip install arxiv-latex-cleaner
 ```
 
-| :exclamation:  arxiv_latex_cleaner is only compatible with Python >=3  :exclamation: |
-|--------------------------------------------------------------------------------------|
+| :exclamation: arxiv_latex_cleaner is only compatible with Python >=3 |
+: \:exclamation\:                                                      :
+| -------------------------------------------------------------------- |
 
 Alternatively, you can download the source code:
 
@@ -50,7 +51,8 @@ python setup.py install
     and `\iffalse\fi` environments.
 *   Optionally removes user-defined commands entered with `commands_to_delete`
     (such as `\todo{}` that you redefine as the empty string at the end).
-*   Optionally allows you to define custom regex replacement rules through a `cleaner_config.yaml` file.
+*   Optionally allows you to define custom regex replacement rules through a
+    `cleaner_config.yaml` file.
 
 #### Size-oriented
 
@@ -69,22 +71,27 @@ There is a 50MB limit on arXiv submissions, so to make it fit:
 
 #### TikZ picture source code concealment
 
-To prevent the upload of tikzpicture source code or raw simulation
-data, this feature:
+To prevent the upload of tikzpicture source code or raw simulation data, this
+feature:
 
-*   Replaces the tikzpicture environment `\begin{tikzpicture} ... \end{tikzpicture}`
-    with the respective `\includegraphics{EXTERNAL_TIKZ_FOLDER/picture_name.pdf}`.
-*   Requires externally compiled TikZ pictures as `.pdf` files in folder `EXTERNAL_TIKZ_FOLDER`.
-    See section 53 in the [PGF/TikZ manual](https://ctan.org/pkg/pgf?lang=en) on TikZ picture externalization.
-*   Only replaces environments with preceding `\tikzsetnextfilename{picture_name}` command
-    (as in `\tikzsetnextfilename{picture_name}\begin{tikzpicture} ... \end{tikzpicture}`) where
-    the externalized `picture_name.pdf` filename matches `picture_name`.
-
+*   Replaces the tikzpicture environment `\begin{tikzpicture} ...
+    \end{tikzpicture}` with the respective
+    `\includegraphics{EXTERNAL_TIKZ_FOLDER/picture_name.pdf}`.
+*   Requires externally compiled TikZ pictures as `.pdf` files in folder
+    `EXTERNAL_TIKZ_FOLDER`. See section 53 in the
+    [PGF/TikZ manual](https://ctan.org/pkg/pgf?lang=en) on TikZ picture
+    externalization.
+*   Only replaces environments with preceding
+    `\tikzsetnextfilename{picture_name}` command (as in
+    `\tikzsetnextfilename{picture_name}\begin{tikzpicture} ...
+    \end{tikzpicture}`) where the externalized `picture_name.pdf` filename
+    matches `picture_name`.
 
 #### More sophisticated pattern replacement based on regex group captures
 
-Sometimes it is useful to work with a set of custom latex commands when writing a paper.
-To get rid of them upon arXiv submission, one can simply revert them to plain latex with a regex insertion.
+Sometimes it is useful to work with a set of custom LaTeX commands when writing
+a paper. To get rid of them upon arXiv submission, one can simply revert them to
+plain LaTeX with a regular expression insertion.
 
 ```yaml
 {
@@ -94,11 +101,16 @@ To get rid of them upon arXiv submission, one can simply revert them to plain la
 }
 ```
 
-The pattern above will find all `\figcomp{path}{w1}{w2}` commands and replace them with
+The pattern above will find all `\figcomp{path}{w1}{w2}` commands and replace
+them with
 `\parbox[c]{w1\linewidth}{\includegraphics[width=w2\linewidth]{figures/path}}`.
-Note that the insertion template is filled with the [named groups captures](https://docs.python.org/3/library/re.html#regular-expression-examples) from the pattern.
-Note that the replacement is processed **before** all `\includegraphics` commands are processed and corresponding file paths are copied, making sure all figure files are copied to the cleaned version.
-See also [cleaner_config.yaml](cleaner_config.yaml) for details on how to specify the patterns.
+Note that the insertion template is filled with the
+[named groups captures](https://docs.python.org/3/library/re.html#regular-expression-examples)
+from the pattern. Note that the replacement is processed **before** all
+`\includegraphics` commands are processed and corresponding file paths are
+copied, making sure all figure files are copied to the cleaned version. See also
+[cleaner_config.yaml](cleaner_config.yaml) for details on how to specify the
+patterns.
 
 ## Usage:
 
@@ -141,7 +153,7 @@ optional arguments:
                         Folder (relative to input folder) containing
                         externalized TikZ figures in PDF format.
   --verbose             Enable detailed output.
-  --config CONFIG_PATH  
+  --config CONFIG_PATH
                         Read Settings from config file, such as "cleaner_config.yaml"
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ arXiv.
 arxiv_latex_cleaner /path/to/latex --im_size 500 --images_whitelist='{"images/im.png":2000}'
 ```
 
+Or simply from a config file
+
+```console
+arxiv_latex_cleaner /path/to/latex --config cleaner_config.yaml
+```
+
 ## Installation:
 
 ```console
@@ -44,6 +50,7 @@ python setup.py install
     and `\iffalse\fi` environments.
 *   Optionally removes user-defined commands entered with `commands_to_delete`
     (such as `\todo{}` that you redefine as the empty string at the end).
+*   Optionally allows you to define custom regex replacement rules through a `cleaner_config.yaml` file.
 
 #### Size-oriented
 
@@ -73,6 +80,26 @@ data, this feature:
     (as in `\tikzsetnextfilename{picture_name}\begin{tikzpicture} ... \end{tikzpicture}`) where
     the externalized `picture_name.pdf` filename matches `picture_name`.
 
+
+#### More sophisticated pattern replacement based on regex group captures
+
+Sometimes it is useful to work with a set of custom latex commands when writing a paper.
+To get rid of them upon arXiv submission, one can simply revert them to plain latex with a regex insertion.
+
+```yaml
+{
+    "pattern" : '(?:\\figcomp{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}',
+    "insertion" : '\parbox[c]{{ {second} \linewidth}} {{ \includegraphics[width= {third} \linewidth]{{figures/{first} }} }}',
+    "description" : "Replace figcomp"
+}
+```
+
+The pattern above will find all `\figcomp{path}{w1}{w2}` commands and replace them with
+`\parbox[c]{w1\linewidth}{\includegraphics[width=w2\linewidth]{figures/path}}`.
+Note that the insertion template is filled with the [named groups captures](https://docs.python.org/3/library/re.html#regular-expression-examples) from the pattern.
+Note that the replacement is processed **before** all `\includegraphics` commands are processed and corresponding file paths are copied, making sure all figure files are copied to the cleaned version.
+See also [cleaner_config.yaml](cleaner_config.yaml) for details on how to specify the patterns.
+
 ## Usage:
 
 ```
@@ -81,6 +108,8 @@ usage: arxiv_latex_cleaner@v0.1.8 [-h] [--resize_images] [--im_size IM_SIZE]
                                   [--pdf_im_resolution PDF_IM_RESOLUTION]
                                   [--images_whitelist IMAGES_WHITELIST]
                                   [--commands_to_delete COMMANDS_TO_DELETE [COMMANDS_TO_DELETE ...]]
+                                  [--verbose]
+                                  [--config CONFIG_PATH]
                                   input_folder
 
 Clean the LaTeX code of your paper to submit to arXiv. Check the README for
@@ -111,6 +140,9 @@ optional arguments:
   --use_external_tikz EXTERNAL_TIKZ_FOLDER
                         Folder (relative to input folder) containing
                         externalized TikZ figures in PDF format.
+  --verbose             Enable detailed output.
+  --config CONFIG_PATH  
+                        Read Settings from config file, such as "cleaner_config.yaml"
 ```
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ arxiv_latex_cleaner /path/to/latex --config cleaner_config.yaml
 pip install arxiv-latex-cleaner
 ```
 
-| :exclamation: arxiv_latex_cleaner is only compatible with Python >=3 |
-: \:exclamation\:                                                      :
-| -------------------------------------------------------------------- |
+| :exclamation:  arxiv_latex_cleaner is only compatible with Python >=3  :exclamation: |
+|--------------------------------------------------------------------------------------|
 
 Alternatively, you can download the source code:
 

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -12,22 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-Main module for ``arxiv_latex_cleaner``
+"""Main module for ``arxiv_latex_cleaner``.
 
 .. code-block:: bash
 
     $ python -m arxiv_latex_cleaner --help
 """
-
-from ._version import __version__
-from .arxiv_latex_cleaner import run_arxiv_cleaner, merge_args_into_config
-
 import argparse
 import json
-import yaml
 import logging
+
+from ._version import __version__
+from .arxiv_latex_cleaner import merge_args_into_config
+from .arxiv_latex_cleaner import run_arxiv_cleaner
+
+import yaml
 
 PARSER = argparse.ArgumentParser(
     prog="arxiv_latex_cleaner@{0}".format(__version__),
@@ -36,8 +35,7 @@ PARSER = argparse.ArgumentParser(
 )
 
 PARSER.add_argument(
-    "input_folder", type=str, help="Input folder containing the LaTeX code."
-)
+    "input_folder", type=str, help="Input folder containing the LaTeX code.")
 
 PARSER.add_argument(
     "--resize_images",
@@ -88,37 +86,37 @@ PARSER.add_argument(
 PARSER.add_argument(
     "--config",
     type=str,
-    help="Read settings from `.yaml` config file. If command line arguments are provided additionally, the config file parameters are updated with the command line parameters.",
+    help=("Read settings from `.yaml` config file. If command line arguments "
+          "are provided additionally, the config file parameters are updated "
+          "with the command line parameters."),
     required=False,
 )
 
 PARSER.add_argument(
-    "--verbose", action="store_true", help="Enable detailed output.",
+    "--verbose",
+    action="store_true",
+    help="Enable detailed output.",
 )
-
 
 ARGS = vars(PARSER.parse_args())
 
-
 if ARGS["config"] is not None:
-    try:
-        with open(ARGS["config"], "r") as config_file:
-            config_params = yaml.safe_load(config_file)
-        final_args = merge_args_into_config(ARGS, config_params)
+  try:
+    with open(ARGS["config"], "r") as config_file:
+      config_params = yaml.safe_load(config_file)
+    final_args = merge_args_into_config(ARGS, config_params)
 
-    except FileNotFoundError:
-        print(f"config file {ARGS.config} not found.")
-        final_args = ARGS
-        final_args.pop("config", None)
-else:
+  except FileNotFoundError:
+    print(f"config file {ARGS.config} not found.")
     final_args = ARGS
-
+    final_args.pop("config", None)
+else:
+  final_args = ARGS
 
 if final_args.get("verbose", False):
-    logging.basicConfig(level=logging.INFO)
+  logging.basicConfig(level=logging.INFO)
 else:
-    logging.basicConfig(level=logging.ERROR)
-
+  logging.basicConfig(level=logging.ERROR)
 
 run_arxiv_cleaner(final_args)
 exit(0)

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -27,6 +27,7 @@ from .arxiv_latex_cleaner import run_arxiv_cleaner, merge_args_into_config
 import argparse
 import json
 import yaml
+import logging
 
 PARSER = argparse.ArgumentParser(
     prog="arxiv_latex_cleaner@{0}".format(__version__),
@@ -106,6 +107,13 @@ if ARGS["config"] is not None:
         final_args.pop("config", None)
 else:
     final_args = ARGS
+
+
+if final_args.get("verbose", False):
+    logging.basicConfig(level=logging.INFO)
+else:
+    logging.basicConfig(level=logging.ERROR)
+
 
 run_arxiv_cleaner(final_args)
 exit(0)

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -22,10 +22,11 @@ Main module for ``arxiv_latex_cleaner``
 """
 
 from ._version import __version__
-from .arxiv_latex_cleaner import run_arxiv_cleaner
+from .arxiv_latex_cleaner import run_arxiv_cleaner, merge_args_into_config
 
 import argparse
 import json
+import yaml
 
 PARSER = argparse.ArgumentParser(
     prog="arxiv_latex_cleaner@{0}".format(__version__),
@@ -84,9 +85,27 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
-    "--use_external_tikz", type=str, help="Folder (relative to input folder) containing externalized tikz figures in PDF format."
+    "--config",
+    type=str,
+    help="Read settings from `.yaml` config file. If command line arguments are provided additionally, the config file parameters are updated with the command line parameters.",
+    required=False,
 )
 
 ARGS = vars(PARSER.parse_args())
-run_arxiv_cleaner(ARGS)
+
+
+if ARGS["config"] is not None:
+    try:
+        with open(ARGS["config"], "r") as config_file:
+            config_params = yaml.safe_load(config_file)
+        final_args = merge_args_into_config(ARGS, config_params)
+
+    except FileNotFoundError:
+        print(f"config file {ARGS.config} not found.")
+        final_args = ARGS
+        final_args.pop("config", None)
+else:
+    final_args = ARGS
+
+run_arxiv_cleaner(final_args)
 exit(0)

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -92,6 +92,11 @@ PARSER.add_argument(
     required=False,
 )
 
+PARSER.add_argument(
+    "--verbose", action="store_true", help="Enable detailed output.",
+)
+
+
 ARGS = vars(PARSER.parse_args())
 
 

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -384,16 +384,15 @@ def run_arxiv_cleaner(parameters):
 
   splits = _split_all_files(parameters)
 
+    logging.info("Reading all tex files")
   tex_contents = _read_all_tex_contents(
       splits['tex_in_root'] + splits['tex_not_in_root'], parameters)
 
   for tex_file in tex_contents:
-    tex_contents[tex_file] = _remove_comments(tex_contents[tex_file],
-                                              parameters)
+        logging.info(f"Removing comments in file {tex_file}.")
 
   for tex_file in tex_contents:
-    content = _replace_tikzpictures(tex_contents[tex_file],
-                                    splits['external_tikz_figures'])
+        logging.info(f"Replacing Tikz Pictures in file {tex_file}.")
     # If file ends with '\n' already, the split in last line would add an extra
     # '\n', so we remove it.
     tex_contents[tex_file] = content.split('\n')
@@ -402,23 +401,27 @@ def run_arxiv_cleaner(parameters):
   _add_root_tex_files(splits)
 
     for tex_file in splits["tex_to_copy"]:
-        logging.info(f"Processing file {tex_file}")
+        logging.info(f"Replacing patterns in file {tex_file}.")
         content = "\n".join(tex_contents[tex_file])
         content = _find_and_replace_patterns(
             content, parameters.get("patterns_and_insertions", list())
         )
         tex_contents[tex_file] = content
+        new_path = os.path.join(parameters["output_folder"], tex_file)
+        logging.info(f"Writing modified contents to {new_path}.")
         _write_file_content(
-            content, os.path.join(parameters["output_folder"], tex_file),
+            content, new_path,
         )
 
   full_content = '\n'.join(
       ''.join(tex_contents[fn]) for fn in splits['tex_to_copy'])
   _copy_only_referenced_non_tex_not_in_root(parameters, full_content, splits)
-  for non_tex_file in splits['non_tex_in_root']:
+        logging.info(f"Copying non-tex file {non_tex_file}.")
     _copy_file(non_tex_file, parameters)
 
   _resize_and_copy_figures_if_referenced(parameters, full_content, splits)
+
+    logging.info("Outputs written to {}".format(parameters["output_folder"]))
 
 
 def strip_whitespace(text):

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -446,7 +446,7 @@ def merge_args_into_config(args, config_params):
     return final_args
 
 
-def _find_and_replace_patterns(content, patterns_and_insertions, verbose=False):
+def _find_and_replace_patterns(content, patterns_and_insertions):
     """
     content: str
     patterns: List[Dict]
@@ -465,18 +465,16 @@ def _find_and_replace_patterns(content, patterns_and_insertions, verbose=False):
         pattern = pattern_and_insertion["pattern"]
         insertion = pattern_and_insertion["insertion"]
         description = pattern_and_insertion["description"]
-        if verbose:
-            print(f"Processing pattern: '{description}'.")
-
+        logging.info(f"Processing pattern: '{description}'.")
         p = re.compile(pattern)
         m = p.search(content)
         while m is not None:
             local_insertion = insertion.format(**m.groupdict())
             local_insertion = strip_whitespace(local_insertion)
-            if verbose:
-                log_txt = f"{content[m.start():m.end()]:<20} --> {local_insertion}"
-                print(log_txt)
+            logging.info(f"-- Found {content[m.start():m.end()]:<70}")
+            logging.info(f"-- Replacing with {local_insertion:<30}")
             new_content = content[: m.start()] + local_insertion + content[m.end() :]
             content = new_content
             m = p.search(content)
+        logging.info(f"Finished pattern: '{description}'.")
     return content

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -478,18 +478,13 @@ def _find_and_replace_patterns(content, patterns_and_insertions):
         description = pattern_and_insertion["description"]
         logging.info(f"Processing pattern: '{description}'.")
         p = re.compile(pattern)
-        remaining_content = content
-        adjusted_content = ""
-        m = p.search(remaining_content)
+        m = p.search(content)
         while m is not None:
             local_insertion = insertion.format(**m.groupdict())
             local_insertion = strip_whitespace(local_insertion)
-            logging.info(f"Found {remaining_content[m.start():m.end()]:<70}")
+            logging.info(f"Found {content[m.start():m.end()]:<70}")
             logging.info(f"Replacing with {local_insertion:<30}")
-            adjusted_content += remaining_content[: m.start()] + local_insertion
-            remaining_content = remaining_content[m.end() :]
-
-            m = p.search(remaining_content)
-        adjusted_content += remaining_content
+            content = content[: m.start()] + local_insertion + content[m.end() :]
+            m = p.search(content)
         logging.info(f"Finished pattern: '{description}'.")
-    return adjusted_content
+    return content

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -409,3 +409,22 @@ def run_arxiv_cleaner(parameters):
     _copy_file(non_tex_file, parameters)
 
   _resize_and_copy_figures_if_referenced(parameters, full_content, splits)
+
+
+def merge_args_into_config(args, config_params):
+    final_args = copy.deepcopy(config_params)
+    config_keys = config_params.keys()
+    for key, value in args.items():
+        if key in config_keys:
+            if any([isinstance(value, t) for t in [str, bool, float, int]]):
+                # overwrite config value with args value
+                final_args[key] = value
+            elif isinstance(value, list):
+                # append args values to config values
+                final_args[key] = value + config_params[key]
+            elif isinstance(value, dict):
+                # update config params with args params
+                final_args[key].update(**value)
+        else:
+            final_args[key] = value
+    return final_args

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -187,8 +187,8 @@ def _remove_comments(content, parameters):
 
 
 def _replace_tikzpictures(content, figures):
-  """Replaces all tikzpicture environments (with includegraphic commands of
-
+  """
+    Replaces all tikzpicture environments (with includegraphic commands of
     external PDF figures) in the content, and writes it.
   """
 
@@ -286,7 +286,7 @@ def _keep_only_referenced(filenames, contents):
 
 
 def _keep_only_referenced_tex(contents, splits):
-  """Returns the filenames referenced from the tex files themselves
+  """Returns the filenames referenced from the tex files themselves.
 
   It needs various iterations in case one file is referenced from an
   unreferenced file.
@@ -380,24 +380,24 @@ def run_arxiv_cleaner(parameters):
       'figures_to_copy_if_referenced': ['.png$', '.jpg$', '.jpeg$', '.pdf$']
   })
 
-  logging.info("Collecting file structure.")
+  logging.info('Collecting file structure.')
   parameters['output_folder'] = _create_out_folder(parameters['input_folder'])
 
   splits = _split_all_files(parameters)
 
-  logging.info("Reading all tex files")
+  logging.info('Reading all tex files')
   tex_contents = _read_all_tex_contents(
       splits['tex_in_root'] + splits['tex_not_in_root'], parameters)
 
   for tex_file in tex_contents:
-    logging.info(f"Removing comments in file {tex_file}.")
+    logging.info('Removing comments in file %s.', tex_file)
     tex_contents[tex_file] = _remove_comments(tex_contents[tex_file],
                                               parameters)
 
   for tex_file in tex_contents:
-    logging.info(f"Replacing Tikz Pictures in file {tex_file}.")
+    logging.info('Replacing Tikz Pictures in file %s.', tex_file)
     content = _replace_tikzpictures(tex_contents[tex_file],
-                                splits['external_tikz_figures'])
+                                    splits['external_tikz_figures'])
     # If file ends with '\n' already, the split in last line would add an extra
     # '\n', so we remove it.
     tex_contents[tex_file] = content.split('\n')
@@ -405,86 +405,90 @@ def run_arxiv_cleaner(parameters):
   _keep_only_referenced_tex(tex_contents, splits)
   _add_root_tex_files(splits)
 
-  for tex_file in splits["tex_to_copy"]:
-    logging.info(f"Replacing patterns in file {tex_file}.")
-    content = "\n".join(tex_contents[tex_file])
+  for tex_file in splits['tex_to_copy']:
+    logging.info('Replacing patterns in file %s.', tex_file)
+    content = '\n'.join(tex_contents[tex_file])
     content = _find_and_replace_patterns(
-        content, parameters.get("patterns_and_insertions", list())
-    )
+        content, parameters.get('patterns_and_insertions', list()))
     tex_contents[tex_file] = content
-    new_path = os.path.join(parameters["output_folder"], tex_file)
-    logging.info(f"Writing modified contents to {new_path}.")
+    new_path = os.path.join(parameters['output_folder'], tex_file)
+    logging.info('Writing modified contents to %s.', new_path)
     _write_file_content(
-        content, new_path,
+        content,
+        new_path,
     )
 
   full_content = '\n'.join(
       ''.join(tex_contents[fn]) for fn in splits['tex_to_copy'])
   _copy_only_referenced_non_tex_not_in_root(parameters, full_content, splits)
   for non_tex_file in splits['non_tex_in_root']:
-    logging.info(f"Copying non-tex file {non_tex_file}.")
+    logging.info('Copying non-tex file %s.', non_tex_file)
     _copy_file(non_tex_file, parameters)
 
   _resize_and_copy_figures_if_referenced(parameters, full_content, splits)
-  logging.info("Outputs written to {}".format(parameters["output_folder"]))
+  logging.info('Outputs written to %s', parameters['output_folder'])
 
 
 def strip_whitespace(text):
-    """Strip all whitespace characters
-    https://stackoverflow.com/questions/8270092/remove-all-whitespace-in-a-string
-    """
-    pattern = re.compile(r"\s+")
-    text = re.sub(pattern, "", text)
-    return text
+  """Strips all whitespace characters.
+
+  https://stackoverflow.com/questions/8270092/remove-all-whitespace-in-a-string
+  """
+  pattern = re.compile(r'\s+')
+  text = re.sub(pattern, '', text)
+  return text
 
 
 def merge_args_into_config(args, config_params):
-    final_args = copy.deepcopy(config_params)
-    config_keys = config_params.keys()
-    for key, value in args.items():
-        if key in config_keys:
-            if any([isinstance(value, t) for t in [str, bool, float, int]]):
-                # overwrite config value with args value
-                final_args[key] = value
-            elif isinstance(value, list):
-                # append args values to config values
-                final_args[key] = value + config_params[key]
-            elif isinstance(value, dict):
-                # update config params with args params
-                final_args[key].update(**value)
-        else:
-            final_args[key] = value
-    return final_args
+  final_args = copy.deepcopy(config_params)
+  config_keys = config_params.keys()
+  for key, value in args.items():
+    if key in config_keys:
+      if any([isinstance(value, t) for t in [str, bool, float, int]]):
+        # overwrite config value with args value
+        final_args[key] = value
+      elif isinstance(value, list):
+        # append args values to config values
+        final_args[key] = value + config_params[key]
+      elif isinstance(value, dict):
+        # update config params with args params
+        final_args[key].update(**value)
+    else:
+      final_args[key] = value
+  return final_args
 
 
 def _find_and_replace_patterns(content, patterns_and_insertions):
-    """
+  r"""
+
     content: str
     patterns_and_insertions: List[Dict]
 
     Example for patterns_and_insertions:
-    
+
         [
             {
-                "pattern" : r"(?:\\figcompfigures{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}",
-                "insertion" : r"\parbox[c]{{{second}\linewidth}}{{\includegraphics[width={third}\linewidth]{{figures/{first}}}}}}",
+                "pattern" :
+                r"(?:\\figcompfigures{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}",
+                "insertion" :
+                r"\parbox[c]{{{second}\linewidth}}{{\includegraphics[width={third}\linewidth]{{figures/{first}}}}}}",
                 "description": "Replace figcompfigures"
             },
         ]
-    """
-    for pattern_and_insertion in patterns_and_insertions:
-        pattern = pattern_and_insertion["pattern"]
-        insertion = pattern_and_insertion["insertion"]
-        description = pattern_and_insertion["description"]
-        logging.info(f"Processing pattern: '{description}'.")
-        p = re.compile(pattern)
-        m = p.search(content)
-        while m is not None:
-            local_insertion = insertion.format(**m.groupdict())
-            local_insertion = strip_whitespace(local_insertion)
-            logging.info(f"Found {content[m.start():m.end()]:<70}")
-            logging.info(f"Replacing with {local_insertion:<30}")
-            content = content[: m.start()] + local_insertion + content[m.end() :]
-            m = p.search(content)
-        logging.info(f"Finished pattern: '{description}'.")
-    return content
+  """
+  for pattern_and_insertion in patterns_and_insertions:
+    pattern = pattern_and_insertion['pattern']
+    insertion = pattern_and_insertion['insertion']
+    description = pattern_and_insertion['description']
+    logging.info('Processing pattern: %s.', description)
+    p = re.compile(pattern)
+    m = p.search(content)
+    while m is not None:
+      local_insertion = insertion.format(**m.groupdict())
+      local_insertion = strip_whitespace(local_insertion)
+      logging.info(f'Found {content[m.start():m.end()]:<70}')
+      logging.info(f'Replacing with {local_insertion:<30}')
+      content = content[:m.start()] + local_insertion + content[m.end():]
+      m = p.search(content)
+    logging.info('Finished pattern: %s.', description)
+  return content

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -399,12 +399,12 @@ def run_arxiv_cleaner(parameters):
   _add_root_tex_files(splits)
 
     for tex_file in splits["tex_to_copy"]:
+        logging.info(f"Processing file {tex_file}")
         content = "\n".join(tex_contents[tex_file])
         content = _find_and_replace_patterns(
-            content,
-            parameters.get("patterns_and_insertions", list()),
-            parameters.get("verbose", False),
+            content, parameters.get("patterns_and_insertions", list())
         )
+        tex_contents[tex_file] = content
         _write_file_content(
             content, os.path.join(parameters["output_folder"], tex_file),
         )

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -20,51 +20,48 @@ import unittest
 from absl.testing import parameterized
 
 from arxiv_latex_cleaner import arxiv_latex_cleaner
-from arxiv_latex_cleaner.arxiv_latex_cleaner import merge_args_into_config
 from PIL import Image
 
 
 def make_args(
-    input_folder="foo/bar",
+    input_folder='foo/bar',
     resize_images=False,
     im_size=500,
     compress_pdf=False,
     pdf_im_resolution=500,
     images_whitelist={},
     commands_to_delete=[],
-    use_external_tikz="foo/bar/tikz",
+    use_external_tikz='foo/bar/tikz',
 ):
-    args = {
-        "input_folder": input_folder,
-        "resize_images": resize_images,
-        "im_size": im_size,
-        "compress_pdf": compress_pdf,
-        "pdf_im_resolution": pdf_im_resolution,
-        "images_whitelist": images_whitelist,
-        "commands_to_delete": commands_to_delete,
-        "use_external_tikz": use_external_tikz,
-    }
-    return args
+  args = {
+      'input_folder': input_folder,
+      'resize_images': resize_images,
+      'im_size': im_size,
+      'compress_pdf': compress_pdf,
+      'pdf_im_resolution': pdf_im_resolution,
+      'images_whitelist': images_whitelist,
+      'commands_to_delete': commands_to_delete,
+      'use_external_tikz': use_external_tikz,
+  }
+  return args
 
 
 def make_contents():
-    contents = (
-        r"& \figcompfigures{"
-        "\n\timage1.jpg"
-        "\n}{"
-        "\n\t\ww"
-        "\n}{"
-        "\n\t1.0"
-        "\n\t}"
-        "\n& "
-        r"\figcompfigures{image2.jpg}{\ww}{1.0}"
-    )
-    return contents
+  contents = (r'& \figcompfigures{'
+              '\n\timage1.jpg'
+              '\n}{'
+              '\n\t\ww'
+              '\n}{'
+              '\n\t1.0'
+              '\n\t}'
+              '\n& '
+              r'\figcompfigures{image2.jpg}{\ww}{1.0}')
+  return contents
 
 
 def make_patterns():
-    pattern = r"(?:\\figcompfigures{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}"
-    insertion = r"""\parbox[c]{{
+  pattern = r'(?:\\figcompfigures{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}'
+  insertion = r"""\parbox[c]{{
             {second}\linewidth
         }}{{
             \includegraphics[
@@ -73,48 +70,62 @@ def make_patterns():
                 figures/{first}
             }}
         }} """
-    description = "Replace figcompfigures"
-    output = {"pattern": pattern, "insertion": insertion, "description": description}
-    return [output]
+  description = 'Replace figcompfigures'
+  output = {
+      'pattern': pattern,
+      'insertion': insertion,
+      'description': description
+  }
+  return [output]
 
 
 class UnitTests(parameterized.TestCase):
-    @parameterized.named_parameters(
-        {
-            "testcase_name": "empty config",
-            "args": make_args(),
-            "config_params": {},
-            "final_args": make_args(),
-        },
-        {
-            "testcase_name": "empty args",
-            "args": {},
-            "config_params": make_args(),
-            "final_args": make_args(),
-        },
-        {
-            "testcase_name": "args and config provided",
-            "args": make_args(
-                images_whitelist={"path1/": 1000}, commands_to_delete=[r"\todo1"]
-            ),
-            "config_params": make_args(
-                "foo_/bar_",
-                True,
-                1000,
-                True,
-                1000,
-                images_whitelist={"path2/": 1000},
-                commands_to_delete=[r"\todo2"],
-                use_external_tikz="foo_/bar_/tikz_",
-            ),
-            "final_args": make_args(
-                images_whitelist={"path1/": 1000, "path2/": 1000},
-                commands_to_delete=[r"\todo1", r"\todo2"],
-            ),
-        },
-    )
-    def test_merge_args_into_config(self, args, config_params, final_args):
-        self.assertEqual(merge_args_into_config(args, config_params), final_args)
+
+  @parameterized.named_parameters(
+      {
+          'testcase_name': 'empty config',
+          'args': make_args(),
+          'config_params': {},
+          'final_args': make_args(),
+      },
+      {
+          'testcase_name': 'empty args',
+          'args': {},
+          'config_params': make_args(),
+          'final_args': make_args(),
+      },
+      {
+          'testcase_name':
+              'args and config provided',
+          'args':
+              make_args(
+                  images_whitelist={'path1/': 1000},
+                  commands_to_delete=[r'\todo1']),
+          'config_params':
+              make_args(
+                  'foo_/bar_',
+                  True,
+                  1000,
+                  True,
+                  1000,
+                  images_whitelist={'path2/': 1000},
+                  commands_to_delete=[r'\todo2'],
+                  use_external_tikz='foo_/bar_/tikz_',
+              ),
+          'final_args':
+              make_args(
+                  images_whitelist={
+                      'path1/': 1000,
+                      'path2/': 1000
+                  },
+                  commands_to_delete=[r'\todo1', r'\todo2'],
+              ),
+      },
+  )
+  def test_merge_args_into_config(self, args, config_params, final_args):
+    self.assertEqual(
+        arxiv_latex_cleaner.merge_args_into_config(args, config_params),
+        final_args)
 
   @parameterized.named_parameters(
       {
@@ -248,26 +259,49 @@ class UnitTests(parameterized.TestCase):
 
   @parameterized.named_parameters(
       {
-            "testcase_name": "replace_contents",
-            "content": make_contents(),
-            "patterns_and_insertions": make_patterns(),
-            "true_outputs": (
-                r"& \parbox[c]{\ww\linewidth}{\includegraphics[width=1.0\linewidth]{figures/image1.jpg}}"
-                "\n"
-                r"& \parbox[c]{\ww\linewidth}{\includegraphics[width=1.0\linewidth]{figures/image2.jpg}}"
-            ),
-        },
-    )
-    def test_find_and_replace_patterns(
-        self, content, patterns_and_insertions, true_outputs
-    ):
-        output = arxiv_latex_cleaner._find_and_replace_patterns(
-            content, patterns_and_insertions
-        )
-        output = arxiv_latex_cleaner.strip_whitespace(output)
-        true_outputs = arxiv_latex_cleaner.strip_whitespace(true_outputs)
-        self.assertEqual(output, true_outputs)
+          'testcase_name':
+              'replace_contents',
+          'content':
+              make_contents(),
+          'patterns_and_insertions':
+              make_patterns(),
+          'true_outputs': (
+              r'& \parbox[c]{\ww\linewidth}{\includegraphics[width=1.0\linewidth]{figures/image1.jpg}}'
+              '\n'
+              r'& \parbox[c]{\ww\linewidth}{\includegraphics[width=1.0\linewidth]{figures/image2.jpg}}'
+          ),
+      },)
+  def test_find_and_replace_patterns(self, content, patterns_and_insertions,
+                                     true_outputs):
+    output = arxiv_latex_cleaner._find_and_replace_patterns(
+        content, patterns_and_insertions)
+    output = arxiv_latex_cleaner.strip_whitespace(output)
+    true_outputs = arxiv_latex_cleaner.strip_whitespace(true_outputs)
+    self.assertEqual(output, true_outputs)
 
+  @parameterized.named_parameters(
+      {
+          'testcase_name': 'no_tikz',
+          'text_in': 'Foo\n',
+          'figures_in': ['ext_tikz/test1.pdf', 'ext_tikz/test2.pdf'],
+          'true_output': 'Foo\n'
+      }, {
+          'testcase_name':
+              'tikz_no_match',
+          'text_in':
+              'Foo\\tikzsetnextfilename{test_no_match}\n\\begin{tikzpicture}\n\\node (test) at (0,0) {Test1};\n\\end{tikzpicture}\nFoo',
+          'figures_in': ['ext_tikz/test1.pdf', 'ext_tikz/test2.pdf'],
+          'true_output':
+              'Foo\\tikzsetnextfilename{test_no_match}\n\\begin{tikzpicture}\n\\node (test) at (0,0) {Test1};\n\\end{tikzpicture}\nFoo'
+      }, {
+          'testcase_name':
+              'tikz_match',
+          'text_in':
+              'Foo\\tikzsetnextfilename{test2}\n\\begin{tikzpicture}\n\\node (test) at (0,0) {Test1};\n\\end{tikzpicture}\nFoo',
+          'figures_in': ['ext_tikz/test1.pdf', 'ext_tikz/test2.pdf'],
+          'true_output':
+              'Foo\\includegraphics{ext_tikz/test2.pdf}\nFoo'
+      })
   def test_replace_tikzpictures(self, text_in, figures_in, true_output):
     self.assertEqual(
         arxiv_latex_cleaner._replace_tikzpictures(text_in, figures_in),

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -20,10 +20,70 @@ import unittest
 from absl.testing import parameterized
 
 from arxiv_latex_cleaner import arxiv_latex_cleaner
+from arxiv_latex_cleaner.arxiv_latex_cleaner import merge_args_into_config
 from PIL import Image
 
 
+def make_args(
+    input_folder="foo/bar",
+    resize_images=False,
+    im_size=500,
+    compress_pdf=False,
+    pdf_im_resolution=500,
+    images_whitelist={},
+    commands_to_delete=[],
+    use_external_tikz="foo/bar/tikz",
+):
+    args = {
+        "input_folder": input_folder,
+        "resize_images": resize_images,
+        "im_size": im_size,
+        "compress_pdf": compress_pdf,
+        "pdf_im_resolution": pdf_im_resolution,
+        "images_whitelist": images_whitelist,
+        "commands_to_delete": commands_to_delete,
+        "use_external_tikz": use_external_tikz,
+    }
+    return args
+
+
 class UnitTests(parameterized.TestCase):
+    @parameterized.named_parameters(
+        {
+            "testcase_name": "empty config",
+            "args": make_args(),
+            "config_params": {},
+            "final_args": make_args(),
+        },
+        {
+            "testcase_name": "empty args",
+            "args": {},
+            "config_params": make_args(),
+            "final_args": make_args(),
+        },
+        {
+            "testcase_name": "args and config provided",
+            "args": make_args(
+                images_whitelist={"path1/": 1000}, commands_to_delete=[r"\todo1"]
+            ),
+            "config_params": make_args(
+                "foo_/bar_",
+                True,
+                1000,
+                True,
+                1000,
+                images_whitelist={"path2/": 1000},
+                commands_to_delete=[r"\todo2"],
+                use_external_tikz="foo_/bar_/tikz_",
+            ),
+            "final_args": make_args(
+                images_whitelist={"path1/": 1000, "path2/": 1000},
+                commands_to_delete=[r"\todo1", r"\todo2"],
+            ),
+        },
+    )
+    def test_merge_args_into_config(self, args, config_params, final_args):
+        self.assertEqual(merge_args_into_config(args, config_params), final_args)
 
   @parameterized.named_parameters(
       {

--- a/cleaner_config.yaml
+++ b/cleaner_config.yaml
@@ -1,0 +1,16 @@
+patterns_and_insertions:
+    [
+        # Use single ticks for regex patterns
+        # http://blogs.perl.org/users/tinita/2018/03/strings-in-yaml---to-quote-or-not-to-quote.html
+        # You still need to escape \ with \\
+        # Use Python named groups https://docs.python.org/3/library/re.html#regular-expression-examples
+        {
+            "pattern" : '(?:\\figcomp{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}',
+            "insertion" : '\parbox[c]{{ {second} \linewidth}} {{ \includegraphics[width= {third} \linewidth]{{figures/{first} }} }}',
+            "description" : "Replace figcomp"
+        },
+    ]
+verbose: False
+commands_to_delete: [
+    '\\todo',
+]

--- a/cleaner_config.yaml
+++ b/cleaner_config.yaml
@@ -2,8 +2,9 @@ patterns_and_insertions:
     [
         # Use single ticks for regex patterns
         # http://blogs.perl.org/users/tinita/2018/03/strings-in-yaml---to-quote-or-not-to-quote.html
-        # You still need to escape \ with \\
+        # You need to escape \ with \\ in the pattern, for instance for \\todo
         # Use Python named groups https://docs.python.org/3/library/re.html#regular-expression-examples
+        # Escape {{ and }} in the insertion expression
         {
             "pattern" : '(?:\\figcomp{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}',
             "insertion" : '\parbox[c]{{ {second} \linewidth}} {{ \includegraphics[width= {third} \linewidth]{{figures/{first} }} }}',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 absl_py~=0.6.1
 pillow>=6.2.0
+pyyaml


### PR DESCRIPTION
Hi,


I was trying to submit to arXiv and came across the great arxiv-latex-cleaner tool to help me get my paper onto arXiv. Unfortunately, the tool did not have all the features I needed, so I decided to just add everything that I needed into it.

The features include:
- support for reading a config file which contains the settings used for the cleaner
- support for performing arbitrary regex searches and inserting the captured groups into defined templates
- verbose output for debugging


I was not sure which python formatter you guys use, so I guess I will have to make a formatting commit at the end.
Furthermore, I am not sure how to increment the version number correctly.

Let me know what you think. I think now that the functionality is there, some functionality could be absorbed into the more general regex substitution pipeline. For example, `_remove_commands` and `_remove_patterns` could be transformed into an empty insertion. This would have the advantage that the pipeline is more transparent, flexible, and in general supports multiline expressions.


Cheers 🍺