### PR TITLE
Fix external_tikz regression

### DIFF
--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -84,6 +84,13 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--use_external_tikz",
+    type=str,
+    help="Folder (relative to input folder) containing externalized tikz "
+         "figures in PDF format."
+)
+
+PARSER.add_argument(
     "--config",
     type=str,
     help=("Read settings from `.yaml` config file. If command line arguments "


### PR DESCRIPTION
Fix a regression introduced by commit 8310b0f8be3682165c9022d4053d7bab26c9798f which removed the --use_external_tikz command-line switch