### PR TITLE
Optionally disable strip_whitespace for pattern replacement

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -482,12 +482,14 @@ def _find_and_replace_patterns(content, patterns_and_insertions):
     pattern = pattern_and_insertion['pattern']
     insertion = pattern_and_insertion['insertion']
     description = pattern_and_insertion['description']
+    strip = pattern_and_insertion.get('strip_whitespace', True)
     logging.info('Processing pattern: %s.', description)
     p = re.compile(pattern)
     m = p.search(content)
     while m is not None:
       local_insertion = insertion.format(**m.groupdict())
-      local_insertion = strip_whitespace(local_insertion)
+      if strip:
+        local_insertion = strip_whitespace(local_insertion)
       logging.info(f'Found {content[m.start():m.end()]:<70}')
       logging.info(f'Replacing with {local_insertion:<30}')
       content = content[:m.start()] + local_insertion + content[m.end():]

--- a/cleaner_config.yaml
+++ b/cleaner_config.yaml
@@ -5,10 +5,15 @@ patterns_and_insertions:
         # You need to escape \ with \\ in the pattern, for instance for \\todo
         # Use Python named groups https://docs.python.org/3/library/re.html#regular-expression-examples
         # Escape {{ and }} in the insertion expression
+        # 
+        # Optional:
+        # Set strip_whitespace to n to disable white space stripping while replacing the pattern. (Default: y)
+
         {
             "pattern" : '(?:\\figcomp{\s*)(?P<first>.*?)\s*}\s*{\s*(?P<second>.*?)\s*}\s*{\s*(?P<third>.*?)\s*}',
             "insertion" : '\parbox[c]{{ {second} \linewidth}} {{ \includegraphics[width= {third} \linewidth]{{figures/{first} }} }}',
-            "description" : "Replace figcomp"
+            "description" : "Replace figcomp",
+            #"strip_whitespace": n 
         },
     ]
 verbose: False


### PR DESCRIPTION
This PR adds a new flag `strip_whitespace` for pattern replacement.
