### PR TITLE
Add the option to keep the bib files

### DIFF
--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -75,6 +75,12 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--keep_bib",
+    action="store_true",
+    help="Avoid deleting the *.bib files.",
+)
+
+PARSER.add_argument(
     "--commands_to_delete",
     nargs="+",
     default=[],

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -370,13 +370,17 @@ def _create_out_folder(input_folder):
 
 def run_arxiv_cleaner(parameters):
   """Core of the code, runs the actual arXiv cleaner."""
+
+  files_to_delete = [r'\.aux$', r'\.sh$', r'\.blg$', r'\.brf$', r'\.log$',
+                     r'\.out$', r'\.ps$', r'\.dvi$', r'\.synctex.gz$', '~$', r'\.backup$',
+                     r'\.gitignore$', r'\.DS_Store$', r'\.svg$', r'^\.idea', r'\.dpth$',
+                     r'\.md5$', r'\.dep$', r'\.auxlock$']
+
+  if not parameters['keep_bib']:
+    files_to_delete.append(r'\.bib$')
+
   parameters.update({
-      'to_delete': [
-          r'\.aux$', r'\.sh$', r'\.bib$', r'\.blg$', r'\.brf$', r'\.log$',
-          r'\.out$', r'\.ps$', r'\.dvi$', r'\.synctex.gz$', '~$', r'\.backup$',
-          r'\.gitignore$', r'\.DS_Store$', r'\.svg$', r'^\.idea', r'\.dpth$',
-          r'\.md5$', r'\.dep$', r'\.auxlock$'
-      ],
+      'to_delete': files_to_delete,
       'figures_to_copy_if_referenced': [
           r'\.png$', r'\.jpg$', r'\.jpeg$', r'\.pdf$'
       ]


### PR DESCRIPTION
This PR follows @jponttuset comment https://github.com/google-research/arxiv-latex-cleaner/issues/28#issuecomment-667578262 and fixes https://github.com/google-research/arxiv-latex-cleaner/issues/28. 

In detail, if the user calls the module with the option `--keep_bib` the bib files are not deleted. 