### PR TITLE
Clarify location of new folder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This tool allows you to easily clean the LaTeX code of your paper to submit to
 arXiv. From a folder containing all your code, e.g. `/path/to/latex/`, it
 creates a new folder `/path/to/latex_arXiv/`, that is ready to ZIP and upload to
-arXiv.
+arXiv. On Linux, if you call it with `.` as input directory, the new folder
+will be the hidden folder `._arXiv` inside the source folder.
 
 ## Example call:
 


### PR DESCRIPTION
I wanted to call the tool from inside the source directory, so I tested it with `.` as input folder path. It worked and created the new directory as `._arXiv` inside the source folder. I only tested on Ubuntu.

The code suggests confirms this behaviour: https://github.com/google-research/arxiv-latex-cleaner/blob/1ef87e94732cc3b3292e69dfe465d5f4c663fa91/arxiv_latex_cleaner/arxiv_latex_cleaner.py#L365
```python
out_folder = input_folder.rstrip(os.sep) + '_arXiv'
```
If `input_folder` is just `.`, then `out_folder` will become `._arXiv`.

I thought this could be a valuable addition to the manual/README. Feel free to move it to another location.