### PR TITLE
Fix the order of args in gs to actually disable AutoRotatePages

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -27,8 +27,8 @@ from PIL import Image
 PDF_RESIZE_COMMAND = (
     'gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dNOPAUSE -dQUIET -dBATCH '
     '-dDownsampleColorImages=true -dColorImageResolution={resolution} '
-    '-dColorImageDownsampleThreshold=1.0 -sOutputFile={output} {input} '
-    '-dAutoRotatePages=/None')
+    '-dColorImageDownsampleThreshold=1.0 -dAutoRotatePages=/None '
+    '-sOutputFile={output} {input}')
 MAX_FILENAME_LENGTH = 120
 
 # Fix for Windows: Even if '\' (os.sep) is the standard way of making paths on


### PR DESCRIPTION
The previous order of args did not capture `-dAutoRotatePages=/None`. It leads to unexpected behavior when compressing a pdf with a vertical major orientation of the text.