### PR TITLE
Fixes#45: do not clean content after commented \end{document}.

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -175,10 +175,10 @@ def _remove_comments_inline(text):
 def _strip_tex_contents(lines, end_str):
   """Removes everything after end_str."""
   for i in range(len(lines)):
-    if end_str in lines[i] and '%' not in lines[i]:
-      return lines[:i + 1]
-    if end_str in lines[i] and '%' in lines[i]:
-      if lines[i].index('%') > lines[i].index(end_str):
+    if end_str in lines[i]:
+      if '%' not in lines[i]:
+        return lines[:i + 1]
+      elif lines[i].index('%') > lines[i].index(end_str):
         return lines[:i + 1]
   return lines
 

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -175,8 +175,11 @@ def _remove_comments_inline(text):
 def _strip_tex_contents(lines, end_str):
   """Removes everything after end_str."""
   for i in range(len(lines)):
-    if end_str in lines[i]:
+    if end_str in lines[i] and '%' not in lines[i]:
       return lines[:i + 1]
+    if end_str in lines[i] and '%' in lines[i]:
+      if lines[i].index('%') > lines[i].index(end_str):
+        return lines[:i + 1]
   return lines
 
 

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -27,6 +27,8 @@ Text
 \fi
 \fi
 
+% content after this line should not be cleaned if \end{document} is in a comment
+
 \input{figures/figure_included.tex}
 % \input{figures/figure_not_included.tex}
 


### PR DESCRIPTION
This pull request fixes https://github.com/google-research/arxiv-latex-cleaner/issues/45. 
This bug deletes all the content after a line like `% here is \end{document} in comment`.