### PR TITLE
Fixes path split bug and add more tests for `_search_reference`

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -327,9 +327,16 @@ def _search_reference(filename, contents, strict=False):
     unescaped_basename_regex = '{}({})?'.format(root, extension)
     basename_regex = unescaped_basename_regex.replace('.', r'\.')
 
-    path = os.path.dirname(filename)
+    # since os.path.split only splits into two parts
+    # need to iterate and collect all the fragments
+    fragments = []
+    cur_head = os.path.dirname(filename)
+    while cur_head:
+      cur_head, tail = os.path.split(cur_head)
+      fragments.insert(0, tail)  # insert at the beginning
+
     path_prefix_regex = ''
-    for fragment in os.path.split(path):
+    for fragment in fragments:
       path_prefix_regex = '({}{}{})?'.format(path_prefix_regex, fragment,
                                              os.sep)
 


### PR DESCRIPTION
Sequel to #25, added more tests, discovered a bug in the process, fixed the bug, added some more tests.

In case you're curious about the bug, turns out `os.path.split` only splits a path into two parts. So `os.path.split("long/path/to")` will yield `"long/path", "to"`. And, earlier we were iterating over the result of `os.path.split` expecting to get all the parts one by one, i.e. `["long", "path", "to"]`. Now, we first collect all the path fragments and then loop over them.

```python
fragments = []
cur_head = os.path.dirname(filename)
while cur_head:
  cur_head, tail = os.path.split(cur_head)
  fragments.insert(0, tail)  # insert at the beginning
```