### PR TITLE
Fix relative filenames referenced with './' in tex

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -343,6 +343,10 @@ def _search_reference(filename, contents, strict=False):
     # regex pattern for strict=True for path/to/img.ext:
     # \{[\s%]*(<path_prefix>)?<basename>(<ext>)?[\s%]*\}
     filename_regex = path_prefix_regex + basename_regex
+    
+  # some files 'path/to/file' are referenced in tex as './path/to/file'
+  # thus add prefix for relative paths starting with './' or '.\' to regex search
+  filename_regex = r'(.' + os.sep + r')?' + filename_regex
 
   # pad with braces and optional whitespace/comment characters
   patn = r'\{{[\s%]*{}[\s%]*\}}'.format(filename_regex)

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -196,6 +196,12 @@ def make_search_reference_tests():
       'contents': '\\include{tables/demo.csv}',
       'strict': True,
       'true_outputs': ['tables/demo.csv']
+  }, {
+      'testcase_name': 'path_starting_with_dot',
+      'filenames': ['./images/im_included.png', './figures/im_included.png'],
+      'contents': '\\include{./images/im_included.png}',
+      'strict': False,
+      'true_outputs': ['./images/im_included.png']
   })
 
 

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -23,6 +23,9 @@ This is a percent \%.
 %\includegraphics[width=.5\linewidth]{%
 %  images/im5_not_included.jpg}
 
+% test whatever the path satrting with dot works when include graphics
+\includegraphics{./images/im3_included.png}
+
 This line should\mytodo{Do this later} not be separated
 \mytodo{This is a todo command with a nested \textit{command}.
 Please remember that up to \texttt{2 levels} of \textit{nesting} are supported.}

--- a/tex_arXiv_true/main.tex
+++ b/tex_arXiv_true/main.tex
@@ -13,6 +13,8 @@ This is a percent \%.
 \includegraphics[width=.5\linewidth]{%
   images/im5_included.jpg}
 
+\includegraphics{./images/im3_included.png}
+
 This line should not be separated
 %
 from this one.


### PR DESCRIPTION
some files 'path/to/file' are referenced in tex as './path/to/file'
thus add prefix for relative paths starting with './' or '.\' to regex search