### PR TITLE
Remove "\if false" or "\if 0" blocks that contain spaces

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -132,12 +132,12 @@ def _remove_environment(text, environment):
 
 def _remove_iffalse_block(text):
   """Removes possibly nested r'\iffalse*\fi' blocks from 'text'."""
-  p = re.compile(r'\\if(\w+)|\\fi')
+  p = re.compile(r'\\if\s*(\w+)|\\fi')
   level = -1
   positions_to_delete = []
   start, end = 0, 0
   for m in p.finditer(text):
-    if (m.group() == r'\iffalse' or m.group() == r'\if0') and level == -1:
+    if (m.group().replace(" ", "") == r'\iffalse' or m.group().replace(" ", "") == r'\if0') and level == -1:
       level += 1
       start = m.start()
     elif m.group().startswith(r'\if') and level >= 0:

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -31,9 +31,15 @@ from this one.
 \newif\ifvar
 
 \ifvar
+\if    false
+\if false
+\if 0
 \iffalse
 \ifvar
 Text
+\fi
+\fi
+\fi
 \fi
 \fi
 \fi


### PR DESCRIPTION
We often use "\if false" or "\if 0" which contain (several) spaces within the commands. This commit addresses this type of comment block and provides the corresponding unit tests.

This also fixes #52. 