### PR TITLE
Add an option to delete commands but keep their wrapped text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ arXiv.
 
 ## Example call:
 
-```console
+```bash
 arxiv_latex_cleaner /path/to/latex --im_size 500 --images_whitelist='{"images/im.png":2000}'
 ```
 
 Or simply from a config file
 
-```console
+```bash
 arxiv_latex_cleaner /path/to/latex --config cleaner_config.yaml
 ```
 
 ## Installation:
 
-```console
+```bash
 pip install arxiv-latex-cleaner
 ```
 
@@ -28,7 +28,7 @@ pip install arxiv-latex-cleaner
 
 Alternatively, you can download the source code:
 
-```console
+```bash
 git clone https://github.com/google-research/arxiv-latex-cleaner
 cd arxiv-latex-cleaner/
 python -m arxiv_latex_cleaner --help
@@ -36,7 +36,7 @@ python -m arxiv_latex_cleaner --help
 
 And install as a command-line program directly from the source code:
 
-```console
+```bash
 python setup.py install
 ```
 
@@ -168,7 +168,7 @@ optional arguments:
 
 ## Testing:
 
-```
+```bash
 python -m unittest arxiv_latex_cleaner.tests.arxiv_latex_cleaner_test
 ```
 

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -95,6 +95,20 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--commands_only_to_delete",
+    nargs="+",
+    default=[],
+    required=False,
+    help=(
+        "LaTeX commands that will be deleted but the text wrapped in the "
+        "commands will be retained. Useful for commands that change text "
+        "formats and colors, which you may want to remove but keep the "
+        "text within. Usages are exactly the same as commands_to_delete. "
+        "Note that if the commands listed here duplicate that after "
+        "commands_to_delete, the default action will be retaining the wrapped text."),
+)
+
+PARSER.add_argument(
     "--use_external_tikz",
     type=str,
     help=("Folder (relative to input folder) containing externalized tikz "

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -132,12 +132,12 @@ def _remove_environment(text, environment):
 
 def _remove_iffalse_block(text):
   """Removes possibly nested r'\iffalse*\fi' blocks from 'text'."""
-  p = re.compile(r'\\if(\w+)|\\fi')
+  p = re.compile(r'\\if\s*(\w+)|\\fi')
   level = -1
   positions_to_delete = []
   start, end = 0, 0
   for m in p.finditer(text):
-    if (m.group() == r'\iffalse' or m.group() == r'\if0') and level == -1:
+    if (m.group().replace(" ", "") == r'\iffalse' or m.group().replace(" ", "") == r'\if0') and level == -1:
       level += 1
       start = m.start()
     elif m.group().startswith(r'\if') and level >= 0:

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -283,23 +283,52 @@ class UnitTests(parameterized.TestCase):
       {
           'testcase_name': 'no_command',
           'text_in': 'Foo\nFoo2\n',
+          'keep_text': False,
           'true_output': 'Foo\nFoo2\n'
       }, {
           'testcase_name': 'command_not_removed',
           'text_in': '\\textit{Foo\nFoo2}\n',
+          'keep_text': False,
           'true_output': '\\textit{Foo\nFoo2}\n'
       }, {
           'testcase_name': 'command_no_end_line_removed',
           'text_in': 'A\\todo{B\nC}D\nE\n\\end{document}',
+          'keep_text': False,
           'true_output': 'AD\nE\n\\end{document}'
       }, {
           'testcase_name': 'command_with_end_line_removed',
           'text_in': 'A\n\\todo{B\nC}\nD\n\\end{document}',
+          'keep_text': False,
           'true_output': 'A\n%\nD\n\\end{document}'
+      }, {
+          'testcase_name': 'no_command_keep_text',
+          'text_in': 'Foo\nFoo2\n',
+          'keep_text': True,
+          'true_output': 'Foo\nFoo2\n'
+      }, {
+          'testcase_name': 'command_not_removed_keep_text',
+          'text_in': '\\textit{Foo\nFoo2}\n',
+          'keep_text': True,
+          'true_output': '\\textit{Foo\nFoo2}\n'
+      }, {
+          'testcase_name': 'command_no_end_line_removed_keep_text',
+          'text_in': 'A\\todo{B\nC}D\nE\n\\end{document}',
+          'keep_text': True,
+          'true_output': 'AB\nCD\nE\n\\end{document}'
+      }, {
+          'testcase_name': 'command_with_end_line_removed_keep_text',
+          'text_in': 'A\n\\todo{B\nC}\nD\n\\end{document}',
+          'keep_text': True,
+          'true_output': 'A\nB\nC\nD\n\\end{document}'
+      }, {
+          'testcase_name': 'nested_command_keep_text',
+          'text_in': 'A\n\\todo{B\n\\todo{C}}\nD\n\\end{document}',
+          'keep_text': True,
+          'true_output': 'A\nB\nC\nD\n\\end{document}'
       })
-  def test_remove_command(self, text_in, true_output):
+  def test_remove_command(self, text_in, keep_text, true_output):
     self.assertEqual(
-        arxiv_latex_cleaner._remove_command(text_in, 'todo'), true_output)
+        arxiv_latex_cleaner._remove_command(text_in, 'todo', keep_text), true_output)
 
   @parameterized.named_parameters(
       {
@@ -664,6 +693,7 @@ class IntegrationTests(unittest.TestCase):
         'compress_pdf': False,
         'pdf_im_resolution': 500,
         'commands_to_delete': ['mytodo'],
+        'commands_only_to_delete': ['red'],
         'use_external_tikz': 'ext_tikz',
         'keep_bib': False
     })

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -47,6 +47,11 @@ Text
 \fi
 \fi
 
+\newcommand{\red}[1]{{\color{red} #1}}
+hello test \red{hello
+test \red{hello}}
+test
+
 % content after this line should not be cleaned if \end{document} is in a comment
 
 \input{figures/figure_included.tex}

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -31,9 +31,15 @@ from this one.
 \newif\ifvar
 
 \ifvar
+\if    false
+\if false
+\if 0
 \iffalse
 \ifvar
 Text
+\fi
+\fi
+\fi
 \fi
 \fi
 \fi

--- a/tex_arXiv_true/main.tex
+++ b/tex_arXiv_true/main.tex
@@ -24,6 +24,11 @@ from this one.
 \ifvar
 \fi
 
+\newcommand{\red}[1]{{\color{red} #1}}
+hello test hello
+test hello
+test
+
 
 \input{figures/figure_included.tex}
 


### PR DESCRIPTION
### Motivation
I add a command-line option (--commands_only_to_delete) to delete user-defined LaTeX commands but retain the text wrapped in the commands. This is useful for commands that are meant to temporarily change text colors and formats (e.g., some user-defined \red command that makes the text red), which are common in collaborative writing to highlight different people's texts. Such commands should be removed upon submissions but the text within ought to be retained.

### Usage
Usages are exactly the same as --commands_to_delete. Note that if the commands listed here duplicate that after commands_to_delete, the default action will be retaining the wrapped text.

### Modification

1. `__main__.py`: add an option and related help text.
2. `arxiv_latex_cleaner.py`: add an optional parameter to the `_remove_command` function, and keep (or not) the text accordingly.
3. `arxiv_latex_cleaner_test.py`: add unit test cases for `test_remove_command`
4. `tex/main.tex`: add integration test.

Btw, I fix a small bug regarding the `_search_reference` function. I find that picture references in LaTeX are allowed to be in different cases compared to the actual file names. So it's safer to add a `re.IGNORECASE` when doing `re.search`.
