### PR TITLE
Adds Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ pip install arxiv-latex-cleaner
 | :exclamation: arxiv_latex_cleaner is only compatible with Python >=3 :exclamation: |
 | ---------------------------------------------------------------------------------- |
 
+If using MacOS, you can install using [Homebrew](https://brew.sh/):
+
+```bash
+brew install arxiv_latex_cleaner
+```
+
 Alternatively, you can download the source code:
 
 ```bash


### PR DESCRIPTION
Can be installed as `arxiv_latex_cleaner` using Homebrew per [54fb112](https://github.com/Homebrew/homebrew-core/commit/54fb112f004933e4b2c26fa68c7828439f28a724).