### PR TITLE
Fix --commands_to_delete failing to match deeply nested commands and hanging

### DIFF
--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -323,7 +323,13 @@ class UnitTests(parameterized.TestCase):
           'text_in': 'A\n\\todo{B\n\\todo{C}}\nD\n\\end{document}',
           'keep_text': True,
           'true_output': 'A\nB\nC\nD\n\\end{document}'
-      })
+      }, {
+          'testcase_name': 'deeply_nested_command_keep_text',
+          'text_in': 'A\n\\todo{B\n\\emph{C\\footnote{\\textbf{D}}}}\nE\n\\end{document}',
+          'keep_text': True,
+          'true_output': 'A\nB\n\\emph{C\\footnote{\\textbf{D}}}\nE\n\\end{document}'
+      }
+      )
   def test_remove_command(self, text_in, keep_text, true_output):
     self.assertEqual(
         arxiv_latex_cleaner._remove_command(text_in, 'todo', keep_text),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 absl_py>=0.12
 pillow>=6.2.0
 pyyaml
+regex


### PR DESCRIPTION
Fixes #63
- Adds a test case for #63
- Implements a recursive regex pattern to match arbitrarily deeply nested commands, passing the new test case
- Switches to the `regex` package instead of `re` for support of recursive patterns