### PR TITLE
add --resize_images argument in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ arXiv.
 ## Example call:
 
 ```bash
-arxiv_latex_cleaner /path/to/latex --im_size 500 --images_whitelist='{"images/im.png":2000}'
+arxiv_latex_cleaner /path/to/latex --resize_images --im_size 500 --images_whitelist='{"images/im.png":2000}'
 ```
 
 Or simply from a config file


### PR DESCRIPTION
without the --resize_images argument in the first example call in the README file, the argument --im_size 500 has no effect.