### PR TITLE
Add .fls and .fdb_latexmk to list of extensions to delete

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -471,7 +471,7 @@ def run_arxiv_cleaner(parameters):
       r'\.aux$', r'\.sh$', r'\.blg$', r'\.brf$', r'\.log$', r'\.out$', r'\.ps$',
       r'\.dvi$', r'\.synctex.gz$', '~$', r'\.backup$', r'\.gitignore$',
       r'\.DS_Store$', r'\.svg$', r'^\.idea', r'\.dpth$', r'\.md5$', r'\.dep$',
-      r'\.auxlock$'
+      r'\.auxlock$', r'\.fls$', r'\.fdb_latexmk$'
   ]
 
   if not parameters['keep_bib']:


### PR DESCRIPTION
This PR adds `.fls` and `.fdb_latexmk` to the list of file extensions to delete.

These files are generated by default by `latexmk` and are not needed for recompilation. They contain paths to files and directories used during compilation. These paths might contain the system username.