### PR TITLE
Remove user-defined environments

### DIFF
--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -109,6 +109,21 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--environments_to_delete",
+    nargs="+",
+    default=[],
+    required=False,
+    help=(
+        "LaTeX environments that will be deleted. Useful for e.g. user-"
+        "defined comment environments. For example, to delete all occurences "
+        "of \\begin{note} ... \\end{note}, run the tool with "
+        "`--environments_to_delete note`. Please note that the positional "
+        "argument `input_folder` cannot come immediately after "
+        "`environments_to_delete`, as the parser does not have any way to "
+        "know if it's another environment to delete."),
+)
+
+PARSER.add_argument(
     "--use_external_tikz",
     type=str,
     help=("Folder (relative to input folder) containing externalized tikz "

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -138,8 +138,10 @@ def _remove_command(text, command, keep_text=False):
 
 def _remove_environment(text, environment):
   """Removes '\\begin{environment}*\\end{environment}' from 'text'."""
+  # Need to escape '{', to not trigger fuzzy matching if `environment` starts
+  # with one of 'i', 'd', 's', or 'e'
   return regex.sub(
-      r'\\begin{' + environment + r'}[\s\S]*?\\end{' + environment + r'}', '',
+      r'\\begin\{' + environment + r'}[\s\S]*?\\end\{' + environment + r'}', '',
       text)
 
 
@@ -224,6 +226,8 @@ def _remove_comments_and_commands_to_delete(content, parameters):
   content = [_remove_comments_inline(line) for line in content]
   content = _remove_environment(''.join(content), 'comment')
   content = _remove_iffalse_block(content)
+  for environment in parameters.get('environments_to_delete', []):
+    content = _remove_environment(content, environment)
   for command in parameters.get('commands_only_to_delete', []):
     content = _remove_command(content, command, True)
   for command in parameters['commands_to_delete']:

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -753,6 +753,7 @@ class IntegrationTests(unittest.TestCase):
         'pdf_im_resolution': 500,
         'commands_to_delete': ['mytodo'],
         'commands_only_to_delete': ['red'],
+        'environments_to_delete': ['mynote'],
         'use_external_tikz': 'ext_tikz',
         'keep_bib': False
     })

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -31,6 +31,10 @@ This line should\mytodo{Do this later} not be separated
 Please remember that up to \texttt{2 levels} of \textit{nesting} are supported.}
 from this one.
 
+\begin{mynote}
+  This is a custom environment that could be excluded.
+\end{mynote}
+
 \newif\ifvar
 
 \ifvar

--- a/tex_arXiv_true/main.tex
+++ b/tex_arXiv_true/main.tex
@@ -19,6 +19,8 @@ This line should not be separated
 %
 from this one.
 
+
+
 \newif\ifvar
 
 \ifvar


### PR DESCRIPTION
Add new argument `--environments_to_remove` to remove selected environments from the source file analogous to the existing functionality of `--commands_to_remove`.

---

This is pretty much the same as https://github.com/google-research/arxiv-latex-cleaner/pull/49, but the original author appears to have abandoned their PR. This PR hopefully addresses the concerns raised in the review there (mainly a testcase for the new argument).