### PR TITLE
Fixed issue #82: % inside of url link is not treated as comment

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -194,16 +194,35 @@ def _remove_iffalse_block(text):
 
 
 def _remove_comments_inline(text):
-  """Removes the comments from the string 'text'."""
-  if 'auto-ignore' in text:
-    return text
-  if text.lstrip(' ').lstrip('\t').startswith('%'):
-    return ''
-  match = regex.search(r'(?<!\\)%', text)
-  if match:
-    return text[: match.end()] + '\n'
-  else:
-    return text
+    """Removes the comments from the string 'text' and ignores % inside \\url{}."""
+    if "auto-ignore" in text:
+        return text
+    if text.lstrip(" ").lstrip("\t").startswith("%"):
+        return ""
+
+    url_pattern = r"\\url\{(?>[^{}]|(?R))*\}"
+    def remove_comments(segment):
+        """
+        Remove comments from a segment of text.
+        """
+        if segment.lstrip().startswith("%"):
+            return ""
+        match = regex.search(r"(?<!\\)%", segment)
+        if match:
+            return segment[: match.start()] + "\n"
+        else:
+            return segment
+
+    # split the text into segments based on \url{} tags
+    segments = regex.split(f"({url_pattern})", text)
+
+    for i in range(len(segments)):
+        # only process segments that are not part of a \url{} tag
+        if not regex.match(url_pattern, segments[i]):
+            segments[i] = remove_comments(segments[i])
+
+    final_text = "".join(segments)
+    return final_text if final_text.endswith("\n") else final_text + "\n"
 
 
 def _strip_tex_contents(lines, end_str):


### PR DESCRIPTION
This change resolves issue #82 by separating text into segments and not treating any % inside of \url{} as a comment.