### PR TITLE
Bug fix 48: Add optional argument functionality for --commands_to_delete

### DIFF
--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -330,6 +330,18 @@ class UnitTests(parameterized.TestCase):
           'true_output': 'A\n%\nD\n\\end{document}',
       },
       {
+          'testcase_name': 'command_with_optional_arguments_start',
+          'text_in': 'A\n\\todo[B]{C\nD}\nE\n\\end{document}',
+          'keep_text': False,
+          'true_output': 'A\n%\nE\n\\end{document}',
+      },
+      {
+          'testcase_name': 'command_with_optional_arguments_end',
+          'text_in': 'A\n\\todo{B\nC}[D]\nE\n\\end{document}',
+          'keep_text': False,
+          'true_output': 'A\n%\nE\n\\end{document}',
+      },
+      {
           'testcase_name': 'no_command_keep_text',
           'text_in': 'Foo\nFoo2\n',
           'keep_text': True,
@@ -358,6 +370,18 @@ class UnitTests(parameterized.TestCase):
           'text_in': 'A\n\\todo{B\n\\todo{C}}\nD\n\\end{document}',
           'keep_text': True,
           'true_output': 'A\nB\nC\nD\n\\end{document}',
+      },
+      {
+          'testcase_name': 'command_with_optional_arguments_start_keep_text',
+          'text_in': 'A\n\\todo[B]{C\nD}\nE\n\\end{document}',
+          'keep_text': True,
+          'true_output': 'A\nC\nD\nE\n\\end{document}',
+      },
+      {
+          'testcase_name': 'command_with_optional_arguments_end_keep_text',
+          'text_in': 'A\n\\todo{B\nC}[D]\nE\n\\end{document}',
+          'keep_text': True,
+          'true_output': 'A\nB\nC\nE\n\\end{document}',
       },
       {
           'testcase_name': 'deeply_nested_command_keep_text',


### PR DESCRIPTION
This change resolves #48. 

I have modified the `base_pattern` regex to include `(?:\[(?:.*?)\])*` which is a non-greedy match for zero or more occurrences of brackets that serve as optional arguments in LaTeX. 

I have also added 
```
def extract_text_inside_curly_braces(text):
    """Extract text inside of {} from command string"""
    pattern = r"\{((?:[^{}]|(?R))*)\}"

    match = regex.search(pattern, text)

    if match:
      return match.group(1)
    else:
      return ''
```
which serves to extract the text from nested or non-nested commands if `keep_text` is set to true.

Tests to ensure proper functionality have also been added!