### PR TITLE
Correct section for tikz externalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ feature:
     \end{tikzpicture}` with the respective
     `\includegraphics{EXTERNAL_TIKZ_FOLDER/picture_name.pdf}`.
 *   Requires externally compiled TikZ pictures as `.pdf` files in folder
-    `EXTERNAL_TIKZ_FOLDER`. See section 53 in the
+    `EXTERNAL_TIKZ_FOLDER`. See section 52 (Externalization Library) in the
     [PGF/TikZ manual](https://ctan.org/pkg/pgf?lang=en) on TikZ picture
     externalization.
 *   Only replaces environments with preceding


### PR DESCRIPTION
First, thanks for your great tool! It's really helpful. While working with it, I observed a minor incorrectness. 

Motivation: In the current tikz documentation ([PGF manual](https://www.nic.funet.fi/pub/TeX/CTAN/graphics/pgf/base/doc/pgfmanual.pdf)), the section for externalisation changed to 52 instead of 53.

![Screenshot 2024-03-12 at 11 45 59](https://github.com/google-research/arxiv-latex-cleaner/assets/4615245/357584be-0e09-40fc-bd64-e3f6a58cea29)
