### PR TITLE
Fix issue #93

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -212,8 +212,10 @@ def _remove_iffalse_block(text):
 
 def _remove_comments_inline(text):
   """Removes the comments from the string 'text' and ignores % inside \\url{}."""
-  if '%auto-ignore' in text.split():
-    return text
+  auto_ignore_pattern = r'(%\s*auto-ignore).*'
+  if regex.search(auto_ignore_pattern, text):
+    return regex.sub(auto_ignore_pattern, r'\1', text)
+
   if text.lstrip(' ').lstrip('\t').startswith('%'):
     return ''
 

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -212,7 +212,7 @@ def _remove_iffalse_block(text):
 
 def _remove_comments_inline(text):
   """Removes the comments from the string 'text' and ignores % inside \\url{}."""
-  if 'auto-ignore' in text:
+  if '%auto-ignore' in text.split():
     return text
   if text.lstrip(' ').lstrip('\t').startswith('%'):
     return ''

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -279,6 +279,16 @@ class UnitTests(parameterized.TestCase):
           'true_output': '%auto-ignore\n',
       },
       {
+          'testcase_name': 'auto_ignore_middle',
+          'line_in': 'Foo %auto-ignore Bar\n',
+          'true_output': 'Foo %auto-ignore Bar\n',
+      },
+      {
+          'testcase_name': 'auto_ignore_text_with_comment',
+          'line_in': 'Foo auto-ignore % Comment\n',
+          'true_output': 'Foo auto-ignore %\n',
+      },
+      {
           'testcase_name': 'percent',
           'line_in': r'100\% accurate\n',
           'true_output': r'100\% accurate\n',

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -280,8 +280,8 @@ class UnitTests(parameterized.TestCase):
       },
       {
           'testcase_name': 'auto_ignore_middle',
-          'line_in': 'Foo %auto-ignore Bar\n',
-          'true_output': 'Foo %auto-ignore Bar\n',
+          'line_in': 'Foo % auto-ignore Comment\n',
+          'true_output': 'Foo % auto-ignore\n',
       },
       {
           'testcase_name': 'auto_ignore_text_with_comment',


### PR DESCRIPTION
This PR fixes #93. Two new test were added to ensure `auto-ignore` outside a comment tag is treated as normal text.