### PR TITLE
Fix svg_inkscape conversion with svg suffix

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -327,14 +327,19 @@ def _replace_tikzpictures(content, figures):
 def _replace_includesvg(content, svg_inkscape_files):
   def repl_svg(matchobj):
     svg_path = matchobj.group(2)
+    if svg_path.endswith('.svg'):
+       s = svg_path.rsplit('.', 1)
+       svg_path = '_'.join(s)
     svg_filename = os.path.basename(svg_path)
+
     # search in svg_inkscape split if pdf_tex file is available
     matching_pdf_tex_files = _keep_pattern(
         svg_inkscape_files, ['/' + svg_filename + '-tex.pdf_tex']
     )
     if len(matching_pdf_tex_files) == 1:
       options = '' if matchobj.group(1) is None else matchobj.group(1)
-      return f'\\includeinkscape{options}{{{matching_pdf_tex_files[0]}}}'
+      res =  f'\\includeinkscape{options}{{{matching_pdf_tex_files[0]}}}'
+      return res
     else:
       return matchobj.group(0)
 

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -608,12 +608,30 @@ class UnitTests(parameterized.TestCase):
       },
       {
           'testcase_name': 'includesvg_match_with_options',
-          'text_in': 'Foo\\includesvg[width=\\linewidth]{test2}\nFoo',
+          'text_in': 'Foo\\includesvg[width=\\linewidth,scale=0.40]{figs/persdf/test2}\nFoo',
           'figures_in': [
               'ext_svg/test1-tex.pdf_tex',
               'ext_svg/test2-tex.pdf_tex',
           ],
-          'true_output': 'Foo\\includeinkscape[width=\\linewidth]{ext_svg/test2-tex.pdf_tex}\nFoo',
+          'true_output': 'Foo\\includeinkscape[width=\\linewidth,scale=0.40]{ext_svg/test2-tex.pdf_tex}\nFoo',
+      },
+      {
+          'testcase_name': 'includesvg_match_with_options_with_suffix',
+          'text_in': 'Foo\\includesvg[width=\\linewidth]{figs/test2.svg}\nFoo',
+          'figures_in': [
+              'ext_svg/test1-tex.pdf_tex',
+              'ext_svg/test2_svg-tex.pdf_tex',
+          ],
+          'true_output': 'Foo\\includeinkscape[width=\\linewidth]{ext_svg/test2_svg-tex.pdf_tex}\nFoo',
+      },
+       {
+          'testcase_name': 'includesvg_match_with_options_with_dot_with_suffix',
+          'text_in': 'Foo\\includesvg[width=\\linewidth]{figs/test2-0.9.svg}\nFoo',
+          'figures_in': [
+              'ext_svg/test1-tex.pdf_tex',
+              'ext_svg/test2-0.9_svg-tex.pdf_tex',
+          ],
+          'true_output': 'Foo\\includeinkscape[width=\\linewidth]{ext_svg/test2-0.9_svg-tex.pdf_tex}\nFoo',
       },
   )
   def test_replace_includesvg(self, text_in, figures_in, true_output):


### PR DESCRIPTION
Current svg_inkscape  option fails to convert  `\includesvg[test.svg]` to `includeinkscape[test_svg]` becase inkscape will convert test.svg to test_svg during conversion. 
This PR checks whether svg file ends with svg suffix and do the conversion if necessarily.

Tests are also added for this PR.
