### PR TITLE
allow \input for external tikzpictures

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -480,7 +480,7 @@ def _replace_tikzpictures(content, figures):
       return matchobj.group(0)
 
   content = regex.sub(
-      r'\\tikzsetnextfilename{[\s\S]*?\\end{tikzpicture}', get_figure, content
+      r'\\tikzsetnextfilename{[\s\S]*?(:?\\end{tikzpicture}|\\input{\S*?})', get_figure, content
   )
 
   return content


### PR DESCRIPTION
This addresses issue #38.
The problem was that tikzpictures would not be replaced if they were kept in external files and included via `\input{picture.tikz}`. I added an alternative to the regex that captures this pattern.
It worked for my paper :)