### PR TITLE
update to use without the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ patterns.
 ## Usage:
 
 ```
-usage: arxiv_latex_cleaner@v1.0.11 [-h] [--resize_images] [--im_size IM_SIZE]
+usage: arxiv_latex_cleaner [-h] [--resize_images] [--im_size IM_SIZE]
                                    [--compress_pdf]
                                    [--pdf_im_resolution PDF_IM_RESOLUTION]
                                    [--images_allowlist IMAGES_ALLOWLIST]

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -29,7 +29,7 @@ from .arxiv_latex_cleaner import merge_args_into_config
 from .arxiv_latex_cleaner import run_arxiv_cleaner
 
 PARSER = argparse.ArgumentParser(
-    prog="arxiv_latex_cleaner@{0}".format(__version__),
+    prog="arxiv_latex_cleaner",
     description=(
         "Clean the LaTeX code of your paper to submit to arXiv. "
         "Check the README for more information on the use."


### PR DESCRIPTION
In the readme and tool help instructions, it is instructed to use a command that requires the tool version. But actually, the tool works without the tool version. This PR updates the README and code to support this.