### PR TITLE
Initial support for custom if definitions

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -176,6 +176,7 @@ def _remove_environment(text, environment):
       text,
   )
 
+custom_if = {'true' : [], 'false' : []}
 
 def _simplify_conditional_blocks(text, if_exceptions=[]):
   r"""Simplify possibly nested conditional blocks from 'text'.
@@ -187,6 +188,8 @@ def _simplify_conditional_blocks(text, if_exceptions=[]):
   If the conditional tree is malformed, the function will print a warning
   to stderr and return the original text.
   """
+  custom_if_pattern = regex.compile(r'\\newif\\if([^\\]*)\\\1(true|false)')
+
   p = regex.compile(r'(?!(?<=\\newif\s*))\\if\s*(\w+)|\\else(?!\w)|\\fi(?!\w)')
   toplevel_tree = {'left': [], 'right': [], 'kind': 'toplevel', 'parent': None}
 
@@ -287,14 +290,17 @@ def _simplify_conditional_blocks(text, if_exceptions=[]):
         f" --if_exceptions'.\n"
     )
 
+  for m in custom_if_pattern.finditer(text):
+    custom_if[m.group(2)].append(r'\if' + m.group(1))
+
   for m in p.finditer(text):
     m_no_space = m.group().replace(' ', '')
-    if m_no_space == r'\iffalse' or m_no_space == r'\if0':
+    if m_no_space == r'\iffalse' or m_no_space == r'\if0' or m_no_space in custom_if['false']:
       subtree = new_subtree('iffalse')
       subtree['start'] = m
       add_subtree(tree, subtree)
       tree = subtree
-    elif m_no_space == r'\iftrue' or m_no_space == r'\if1':
+    elif m_no_space == r'\iftrue' or m_no_space == r'\if1' or m_no_space in custom_if['true']:
       subtree = new_subtree('iftrue')
       subtree['start'] = m
       add_subtree(tree, subtree)


### PR DESCRIPTION
Works when ifs are only defined once and defined in a file read before they are used. This means that LaTeX that is statically hidden from display in the PDF will not be included in the output.

This was the behaviour I was initially expecting from the tool, but it wasn't too hard to add it. The weakness of this patch is that it relies on file processing order being correct due to the use of a global variable and if an if is defined as both true and false in different files it will go badly. However, that should not happen if there is only one paper being made from the tex files being processed.

I don't think I have done the CLA before, but if you like the patch I can look at doing that.