### PR TITLE
Escape command name in _remove_command regex

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -112,7 +112,7 @@ def _remove_command(text, command, keep_text=False):
   """
   base_pattern = (
       r'\\'
-      + command
+      + regex.escape(command)
       + r'(?:\[(?:.*?)\])*\{((?:[^{}]+|\{(?1)\})*)\}(?:\[(?:.*?)\])*'
   )
 

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -415,6 +415,42 @@ class UnitTests(parameterized.TestCase):
 
   @parameterized.named_parameters(
       {
+          # '.' would match any character if not escaped, so the similarly
+          # named '\todoX' command would be wrongly removed as well.
+          'testcase_name': 'dot',
+          'command': 'todo.',
+          'kept_command': '\\todoX{B}',
+          'removed_command': '\\todo.{C}',
+      },
+      {
+          # '*' is a quantifier; unescaped, the pattern would not match the
+          # literal command '\star*' at all.
+          'testcase_name': 'star',
+          'command': 'star*',
+          'kept_command': '\\start{B}',
+          'removed_command': '\\star*{C}',
+      },
+      {
+          # '+' is a quantifier; unescaped it changes which text matches.
+          'testcase_name': 'plus',
+          'command': 'foo+',
+          'kept_command': '\\foobar{B}',
+          'removed_command': '\\foo+{C}',
+      },
+  )
+  def test_remove_command_escapes_regex_metacharacters_in_name(
+      self, command, kept_command, removed_command
+  ):
+    # A command name with regex metacharacters must be matched literally. The
+    # similarly named command without the metacharacter must be left untouched,
+    # and the targeted command must be removed.
+    text = 'A ' + kept_command + ' B ' + removed_command + ' C\n'
+    output = arxiv_latex_cleaner._remove_command(text, command, False)
+    self.assertIn(kept_command, output)
+    self.assertNotIn(removed_command, output)
+
+  @parameterized.named_parameters(
+      {
           'testcase_name': 'no_environment',
           'text_in': 'Foo\n',
           'true_output': 'Foo\n',


### PR DESCRIPTION
## Problem

`_remove_command` interpolates the user-supplied `command` directly into a regex `base_pattern`:

```python
base_pattern = (
    r'\\'
    + command
    + r'(?:\[(?:.*?)\])*\{((?:[^{}]+|\{(?1)\})*)\}(?:\[(?:.*?)\])*'
)
```

So a command name containing regex metacharacters is matched as a **pattern** rather than **literally**. For example, with `commands_to_delete=['todo.']`:

- `.` matches any character, so `\todoX{...}` is wrongly removed alongside `\todo.{...}` (over-removal).
- Quantifiers like `*`/`+` in a name make the pattern match the wrong span (or fail to match), so the targeted command may not be removed at all (under-removal).

## Fix

Wrap the name with `regex.escape()` so it is matched literally:

```python
    + regex.escape(command)
```

This is consistent with how the rest of this module already builds patterns from
dynamic strings (e.g. the filename handling in `_replace_includegraphics`, which
uses `regex.escape` in several places).

`commands_to_delete` / `commands_only_to_delete` are documented as literal command
names (CLI `--help` and `cleaner_config.yaml`), so literal matching is the intended
behavior; this does not change handling of normal alphabetic command names.

## Tests

Adds a parameterized regression test (`test_remove_command_escapes_regex_metacharacters_in_name`)
covering `.`, `*`, and `+` in command names. Each case asserts the look-alike command is
preserved and the targeted command is removed. The cases fail before this change and pass after;
the full unit-test suite remains green.