### PR TITLE
Fix whitespace stripping when removing inline comments (#73)

### DIFF
--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -376,7 +376,7 @@ def _remove_comments_inline(text):
   if regex.search(auto_ignore_pattern, text):
     return regex.sub(auto_ignore_pattern, r'\1', text)
 
-  if text.lstrip(' ').lstrip('\t').startswith('%'):
+  if text.lstrip().startswith('%'):
     return ''
 
   url_pattern = r'\\url\{(?>[^{}]|(?R))*\}'

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -385,7 +385,9 @@ def _remove_comments_inline(text):
     """Check if a segment of text contains a comment and remove it."""
     if segment.lstrip().startswith('%'):
       return '', True
-    match = regex.search(r'(?<!\\)%', segment)
+    # Do not match \% (as this is the escaped percent symbol),
+    # but do match `\\%` (break line + start of comment).
+    match = regex.search(r'((?<!\\)|\\\\)%', segment)
     if match:
       return segment[: match.end()] + '\n', True
     else:
@@ -455,7 +457,7 @@ def _remove_comments_and_commands_to_delete(content, parameters):
     content = _remove_environment(content, environment)
   for command in parameters.get('commands_only_to_delete', []):
     content = _remove_command(content, command, True)
-  for command in parameters['commands_to_delete']:
+  for command in parameters.get('commands_to_delete', []):
     content = _remove_command(content, command, False)
   return content
 

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -385,11 +385,15 @@ def _remove_comments_inline(text):
     """Check if a segment of text contains a comment and remove it."""
     if segment.lstrip().startswith('%'):
       return '', True
-    match = regex.search(r'(?<!\\)%', segment)
-    if match:
-      return segment[: match.end()] + '\n', True
-    else:
-      return segment, False
+    # Do not match \% (as this is the escaped percent symbol),
+    # but do match `\\%` (break line + start of comment).
+    for match in regex.finditer(r'\\*%', segment):
+      # If there are an odd number of backslashes, the percent char is escaped,
+      # otherwise the percent char is the beginning of a comment.
+      if (len(match[0]) - 1) % 2 == 0:
+        return segment[: match.end()] + '\n', True
+    
+    return segment, False
 
   # split the text into segments based on \url{} tags
   segments = regex.split(f'({url_pattern})', text)
@@ -455,7 +459,7 @@ def _remove_comments_and_commands_to_delete(content, parameters):
     content = _remove_environment(content, environment)
   for command in parameters.get('commands_only_to_delete', []):
     content = _remove_command(content, command, True)
-  for command in parameters['commands_to_delete']:
+  for command in parameters.get('commands_to_delete', []):
     content = _remove_command(content, command, False)
   return content
 

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -304,6 +304,11 @@ class UnitTests(parameterized.TestCase):
           'true_output': 'Foo %\n',
       },
       {
+          'testcase_name': 'comment_inline_with_tab_and_space',
+          'line_in': '\t %Y\n',
+          'true_output': '',
+      },
+      {
           'testcase_name': 'url_with_percent',
           'line_in': '\\url{https://www.example.com/hello%20world}\n',
           'true_output': '\\url{https://www.example.com/hello%20world}\n',

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -290,8 +290,13 @@ class UnitTests(parameterized.TestCase):
       },
       {
           'testcase_name': 'percent',
-          'line_in': r'100\% accurate\n',
-          'true_output': r'100\% accurate\n',
+          'line_in': r'100\% accurate' + '\n',
+          'true_output': r'100\% accurate' + '\n',
+      },
+      {
+          'testcase_name': 'breakline_with_comment',
+          'line_in': r'\\% comment' + '\n',
+          'true_output': r'\\%' + '\n',
       },
       {
           'testcase_name': 'comment',

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -290,8 +290,23 @@ class UnitTests(parameterized.TestCase):
       },
       {
           'testcase_name': 'percent',
-          'line_in': r'100\% accurate\n',
-          'true_output': r'100\% accurate\n',
+          'line_in': r'100\% accurate' + '\n',
+          'true_output': r'100\% accurate' + '\n',
+      },
+      {
+          'testcase_name': 'breakline_with_comment',
+          'line_in': r'\\% comment' + '\n',
+          'true_output': r'\\%' + '\n',
+      },
+      {
+          'testcase_name': 'breakline_with_literal_percent',
+          'line_in': r'\\\% no comment' + '\n',
+          'true_output': r'\\\% no comment' + '\n',
+      },
+      {
+          'testcase_name': 'breakline_with_literal_percent_and_comment',
+          'line_in': r'\\\% no comment\\% comment' + '\n',
+          'true_output': r'\\\% no comment\\%' + '\n',
       },
       {
           'testcase_name': 'comment',


### PR DESCRIPTION
The stripping of whitespace when removing inline comments was slightly off, removing all instances of a space character ` ` and then all instances of tab character `\t` from the left. This did not handle the case when the whitespace symbols occur in a different order.

Fixes #73.

Edit: I went ahead and fixed the bug described in #8 with respect to line breaks, in the second commit. 