### PR TITLE
Add main TeX entry-point filtering and clean bibliography comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ python setup.py install
 *   Removes all auxiliary files (`.aux`, `.log`, `.out`, etc.).
 *   Removes all comments from your code (yes, those are visible on arXiv and you
     do not want them to be). These also include `\begin{comment}\end{comment}`,
-    `\iffalse\fi`, and `\if0\fi` environments.
+    `\iffalse\fi`, and `\if0\fi` environments. Comments in retained `.bib`
+    and `.bbl` files are removed as well.
 *   Optionally removes user-defined commands entered with `commands_to_delete`
     (such as `\todo{}` that you redefine as the empty string at the end).
 *   Optionally allows you to define custom regex replacement rules through a

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ arXiv.
 arxiv_latex_cleaner /path/to/latex --resize_images --im_size 500 --images_allowlist='{"images/im.png":2000}'
 ```
 
+If the folder contains multiple papers or private root-level files, select the
+entry point explicitly:
+
+```bash
+arxiv_latex_cleaner /path/to/latex --main_tex main.tex
+```
+
 Or simply from a config file
 
 ```bash
@@ -65,6 +72,8 @@ There is a 50MB limit on arXiv submissions, so to make it fit:
 
 *   Removes all unused `.tex` files (those that are not in the root and not
     included in any other `.tex` file).
+*   With `--main_tex`, copies only the selected paper and its referenced
+    dependencies, omitting unrelated root-level files as well.
 *   Removes all unused images that take up space (those that are not actually
     included in any used `.tex` file).
 *   Optionally resizes all images to `im_size` pixels, to reduce the size of the
@@ -122,6 +131,7 @@ patterns.
 
 ```
 usage: arxiv_latex_cleaner@v1.0.11 [-h] [--resize_images] [--im_size IM_SIZE]
+                                   [--main_tex MAIN_TEX]
                                    [--compress_pdf]
                                    [--pdf_im_resolution PDF_IM_RESOLUTION]
                                    [--images_allowlist IMAGES_ALLOWLIST]
@@ -146,6 +156,9 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --main_tex MAIN_TEX   Main TeX file, relative to the input folder. When set,
+                        only this file and its referenced dependencies are
+                        copied; unrelated root files are omitted.
   --resize_images       Resize images.
   --im_size IM_SIZE     Size of the output images (in pixels, longest side).
                         Fine tune this to get as close to 10MB as possible.

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -43,6 +43,16 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--main_tex",
+    type=str,
+    help=(
+        "Main TeX file, relative to the input folder. When set, only this "
+        "file and its referenced dependencies are copied; unrelated root "
+        "files are omitted."
+    ),
+)
+
+PARSER.add_argument(
     "--resize_images",
     action="store_true",
     help="Resize images.",

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -735,9 +735,16 @@ def _resize_and_copy_figures_if_referenced(parameters, contents, splits):
     
     filename_changes = {}  # Track PNG -> JPG filename changes
     
-    for image_file in _keep_only_referenced(
-        splits['figures'], contents, strict=False
-    ):
+    if parameters.get('main_tex') is None:
+        referenced_figures = _keep_only_referenced(
+            splits['figures'], contents, strict=False
+        )
+    else:
+        referenced_figures = _keep_only_referenced_prefer_shallow(
+            splits['figures'], contents
+        )
+
+    for image_file in referenced_figures:
         actual_output_filename = _resize_and_copy_figure(
             filename=image_file,
             origin_folder=parameters['input_folder'],

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -798,27 +798,137 @@ def _keep_only_referenced(filenames, contents, strict=False):
   ]
 
 
-def _keep_only_referenced_tex(contents, splits):
+def _keep_only_referenced_prefer_shallow(filenames, contents):
+  """Returns references while resolving duplicate basenames like TeX does.
+
+  A reference without a directory may weakly match the same filename in
+  several folders. In main-file mode, prefer the shallowest match rather than
+  copying every duplicate. An explicitly qualified reference still matches
+  only its corresponding path.
+  """
+  matches = _keep_only_referenced(filenames, contents, strict=False)
+  shallowest = {}
+  matches = sorted(matches, key=lambda item: (item.count(os.sep), item))
+  for filename in matches:
+    basename = pathlib.PurePosixPath(filename).name
+    shallowest.setdefault(basename, filename)
+  return list(shallowest.values())
+
+
+def _keep_only_referenced_tex(contents, splits, main_tex_files=None):
   """Returns the filenames referenced from the tex files themselves.
 
   It needs various iterations in case one file is referenced from an
   unreferenced file.
+
+  If ``main_tex_files`` is provided, only files reachable from those entry
+  points are retained. Otherwise every TeX file in the input root remains an
+  entry point for backwards compatibility.
   """
-  old_referenced = set(splits['tex_in_root'] + splits['tex_not_in_root'])
+  if main_tex_files is None:
+    old_referenced = set(splits['tex_in_root'] + splits['tex_not_in_root'])
+    while True:
+      referenced = set(splits['tex_in_root'])
+      for fn in old_referenced:
+        for fn2 in old_referenced:
+          if regex.search(
+              r'(' + os.path.splitext(fn)[0] + r'[.}])',
+              '\n'.join(contents[fn2]),
+          ):
+            referenced.add(fn)
+
+      if referenced == old_referenced:
+        splits['tex_to_copy'] = list(referenced)
+        return
+
+      old_referenced = referenced.copy()
+
+  tex_files = set(splits['tex_in_root'] + splits['tex_not_in_root'])
+  referenced = set(main_tex_files)
   while True:
-    referenced = set(splits['tex_in_root'])
-    for fn in old_referenced:
-      for fn2 in old_referenced:
-        if regex.search(
-            r'(' + os.path.splitext(fn)[0] + r'[.}])', '\n'.join(contents[fn2])
-        ):
-          referenced.add(fn)
+    old_referenced = referenced.copy()
+    full_content = '\n'.join(
+        ''.join(contents[fn]) for fn in referenced
+    )
+    candidates = tex_files - referenced
+    referenced.update(
+        _keep_only_referenced_prefer_shallow(candidates, full_content)
+    )
 
     if referenced == old_referenced:
-      splits['tex_to_copy'] = list(referenced)
+      splits['tex_to_copy'] = sorted(referenced)
       return
 
-    old_referenced = referenced.copy()
+
+def _normalize_main_tex(main_tex, splits):
+  """Validates and normalizes a main TeX path relative to the input folder."""
+  if main_tex is None:
+    return None
+
+  main_tex = str(pathlib.PurePosixPath(main_tex.replace('\\', '/')))
+  main_path = pathlib.PurePosixPath(main_tex)
+  if main_path.is_absolute() or '..' in main_path.parts:
+    raise ValueError('--main_tex must be a path inside the input folder.')
+  if main_path.suffix.lower() != '.tex':
+    raise ValueError('--main_tex must point to a .tex file.')
+
+  tex_files = set(splits['tex_in_root'] + splits['tex_not_in_root'])
+  if main_tex not in tex_files:
+    raise ValueError(
+        '--main_tex file {!r} was not found in the input folder.'.format(
+            main_tex
+        )
+    )
+  return main_tex
+
+
+def _copy_referenced_non_tex(parameters, contents, splits, main_tex=None):
+  """Copies non-TeX dependencies, optionally omitting unreferenced root files."""
+  if main_tex is None:
+    _copy_only_referenced_non_tex_not_in_root(parameters, contents, splits)
+    for non_tex_file in splits['non_tex_in_root']:
+      logging.info('Copying non-tex file %s.', non_tex_file)
+      _copy_file(non_tex_file, parameters)
+    return
+
+  candidates = splits['non_tex_in_root'] + splits['non_tex_not_in_root']
+
+  # Most non-TeX files should appear with their full filename in the source.
+  # TeX commonly omits extensions only for document classes, packages, and
+  # bibliography-related files, so limit weak matching to those types. This
+  # prevents a reference such as ``{main}`` from retaining an unrelated
+  # ``main.txt`` or ``main.zip`` file.
+  referenced = set(_keep_only_referenced(candidates, contents, strict=True))
+  implicit_extension_files = _keep_pattern(
+      candidates,
+      [
+          r'\.cls$',
+          r'\.sty$',
+          r'\.bst$',
+          r'\.bib$',
+          r'\.bbx$',
+          r'\.cbx$',
+          r'\.lbx$',
+          r'\.clo$',
+          r'\.cfg$',
+          r'\.def$',
+      ],
+  )
+  referenced.update(
+      _keep_only_referenced_prefer_shallow(
+          implicit_extension_files, contents
+      )
+  )
+
+  # LaTeX reads a pre-built bibliography with the main file's basename even
+  # though the .bbl filename does not appear explicitly in the source.
+  main_bbl = os.path.splitext(main_tex)[0] + '.bbl'
+  if main_bbl in candidates:
+    referenced.add(main_bbl)
+
+  for non_tex_file in sorted(referenced):
+    logging.info('Copying referenced non-tex file %s.', non_tex_file)
+    _copy_file(non_tex_file, parameters)
 
 
 def _add_root_tex_files(splits):
@@ -954,6 +1064,7 @@ def run_arxiv_cleaner(parameters):
       parameters['input_folder'] = tempdir
 
     splits = _split_all_files(parameters)
+    main_tex = _normalize_main_tex(parameters.get('main_tex'), splits)
 
     logging.info('Reading all tex files')
     tex_contents = _read_all_tex_contents(
@@ -981,8 +1092,11 @@ def run_arxiv_cleaner(parameters):
       # '\n', so we remove it.
       tex_contents[tex_file] = content.split('\n')
 
-    _keep_only_referenced_tex(tex_contents, splits)
-    _add_root_tex_files(splits)
+    _keep_only_referenced_tex(
+        tex_contents, splits, [main_tex] if main_tex is not None else None
+    )
+    if main_tex is None:
+      _add_root_tex_files(splits)
 
     for tex_file in splits['tex_to_copy']:
       logging.info('Replacing patterns in file %s.', tex_file)
@@ -1001,10 +1115,7 @@ def run_arxiv_cleaner(parameters):
     full_content = '\n'.join(
         ''.join(tex_contents[fn]) for fn in splits['tex_to_copy']
     )
-    _copy_only_referenced_non_tex_not_in_root(parameters, full_content, splits)
-    for non_tex_file in splits['non_tex_in_root']:
-      logging.info('Copying non-tex file %s.', non_tex_file)
-      _copy_file(non_tex_file, parameters)
+    _copy_referenced_non_tex(parameters, full_content, splits, main_tex)
 
     filename_changes = _resize_and_copy_figures_if_referenced(parameters, full_content, splits)
     logging.info('Outputs written to %s', parameters['output_folder'])

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -104,6 +104,21 @@ def _copy_file(filename, params):
   )
 
 
+def _copy_file_cleaning_comments(filename, params):
+  """Copies a file, removing private comments from bibliography sources."""
+  if os.path.splitext(filename)[1].lower() not in ['.bib', '.bbl']:
+    _copy_file(filename, params)
+    return
+
+  content = _read_file_content(
+      os.path.join(params['input_folder'], filename)
+  )
+  content = ''.join(_remove_comments_inline(line) for line in content)
+  _write_file_content(
+      content, os.path.join(params['output_folder'], filename)
+  )
+
+
 def _remove_command(text, command, keep_text=False):
   """Removes '\\command{*}' from the string 'text'.
 
@@ -705,7 +720,7 @@ def _copy_only_referenced_non_tex_not_in_root(parameters, contents, splits):
   for fn in _keep_only_referenced(
       splits['non_tex_not_in_root'], contents, strict=True
   ):
-    _copy_file(fn, parameters)
+    _copy_file_cleaning_comments(fn, parameters)
 
 def _resize_and_copy_figures_if_referenced(parameters, contents, splits):
     """Modified to handle PNG to JPG conversion and reference updates."""
@@ -888,7 +903,7 @@ def _copy_referenced_non_tex(parameters, contents, splits, main_tex=None):
     _copy_only_referenced_non_tex_not_in_root(parameters, contents, splits)
     for non_tex_file in splits['non_tex_in_root']:
       logging.info('Copying non-tex file %s.', non_tex_file)
-      _copy_file(non_tex_file, parameters)
+      _copy_file_cleaning_comments(non_tex_file, parameters)
     return
 
   candidates = splits['non_tex_in_root'] + splits['non_tex_not_in_root']
@@ -928,7 +943,7 @@ def _copy_referenced_non_tex(parameters, contents, splits, main_tex=None):
 
   for non_tex_file in sorted(referenced):
     logging.info('Copying referenced non-tex file %s.', non_tex_file)
-    _copy_file(non_tex_file, parameters)
+    _copy_file_cleaning_comments(non_tex_file, parameters)
 
 
 def _add_root_tex_files(splits):

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -1034,8 +1034,14 @@ class IntegrationTests(parameterized.TestCase):
           'sections/body.tex': '\\lstinputlisting{data/used.txt}\n',
           'paper.cls': '% local document class\n',
           'refs.bst': '% local bibliography style\n',
-          'sources.bib': '@misc{example, title={Example}}\n',
-          'main.bbl': '\\begin{thebibliography}{1}\\end{thebibliography}\n',
+          'sources.bib': (
+              '% private bibliography note\n'
+              '@misc{example, title={Example 51\\% Result}}\n'
+          ),
+          'main.bbl': (
+              '% private generated note\n'
+              '\\begin{thebibliography}{1}\\end{thebibliography}\n'
+          ),
           'data/used.txt': 'referenced data\n',
           'alternate.tex': '\\documentclass{alternate}\n',
           'alternate.cls': '% unrelated document class\n',
@@ -1081,6 +1087,17 @@ class IntegrationTests(parameterized.TestCase):
               'main.bbl',
               'data/used.txt',
           },
+      )
+      bibliography_contents = {}
+      for bibliography_file in ['sources.bib', 'main.bbl']:
+        with open(
+            path.join(input_dir + '_arXiv', bibliography_file),
+            encoding='utf-8',
+        ) as file_obj:
+          bibliography_contents[bibliography_file] = file_obj.read()
+        self.assertNotIn('private', bibliography_contents[bibliography_file])
+      self.assertIn(
+          r'51\% Result', bibliography_contents['sources.bib']
       )
 
   def tearDown(self):

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -1028,6 +1028,7 @@ class IntegrationTests(parameterized.TestCase):
           'main.tex': (
               '\\documentclass{paper}\n'
               '\\input{sections/body}\n'
+              '\\includegraphics{plot}\n'
               '\\bibliographystyle{refs}\n'
               '\\bibliography{sources}\n'
           ),
@@ -1046,6 +1047,8 @@ class IntegrationTests(parameterized.TestCase):
           'alternate.tex': '\\documentclass{alternate}\n',
           'alternate.cls': '% unrelated document class\n',
           'vendor/paper.cls': '% shadowed duplicate document class\n',
+          'plot.pdf': 'referenced figure\n',
+          'vendor/plot.pdf': 'shadowed duplicate figure\n',
           'sections/unused.tex': 'unreferenced section\n',
           'review.txt': 'private review notes\n',
           'source.zip': 'unrelated archive\n',
@@ -1086,6 +1089,7 @@ class IntegrationTests(parameterized.TestCase):
               'sources.bib',
               'main.bbl',
               'data/used.txt',
+              'plot.pdf',
           },
       )
       bibliography_contents = {}

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from os import path
 import shutil
+import tempfile
 import unittest
 from absl.testing import parameterized
 from arxiv_latex_cleaner import arxiv_latex_cleaner
@@ -226,6 +228,26 @@ def make_search_reference_tests():
 
 
 class UnitTests(parameterized.TestCase):
+
+  def test_normalize_main_tex(self):
+    splits = {
+        'tex_in_root': ['main.tex'],
+        'tex_not_in_root': ['sections/body.tex'],
+    }
+    self.assertEqual(
+        arxiv_latex_cleaner._normalize_main_tex('./main.tex', splits),
+        'main.tex',
+    )
+    self.assertEqual(
+        arxiv_latex_cleaner._normalize_main_tex(
+            r'sections\body.tex', splits
+        ),
+        'sections/body.tex',
+    )
+    for invalid in ['../main.tex', '/tmp/main.tex', 'missing.tex', 'main.tikz']:
+      with self.subTest(invalid=invalid):
+        with self.assertRaises(ValueError):
+          arxiv_latex_cleaner._normalize_main_tex(invalid, splits)
 
   @parameterized.named_parameters(
       {
@@ -995,8 +1017,75 @@ class IntegrationTests(parameterized.TestCase):
             path.join(self.out_path, f1), path.join(out_path_true, f1)
         )
 
+  def test_main_tex_omits_unreferenced_root_files(self):
+    with tempfile.TemporaryDirectory() as temp_dir:
+      input_dir = path.join(temp_dir, 'paper')
+      os.makedirs(path.join(input_dir, 'sections'))
+      os.makedirs(path.join(input_dir, 'data'))
+      os.makedirs(path.join(input_dir, 'vendor'))
+
+      files = {
+          'main.tex': (
+              '\\documentclass{paper}\n'
+              '\\input{sections/body}\n'
+              '\\bibliographystyle{refs}\n'
+              '\\bibliography{sources}\n'
+          ),
+          'sections/body.tex': '\\lstinputlisting{data/used.txt}\n',
+          'paper.cls': '% local document class\n',
+          'refs.bst': '% local bibliography style\n',
+          'sources.bib': '@misc{example, title={Example}}\n',
+          'main.bbl': '\\begin{thebibliography}{1}\\end{thebibliography}\n',
+          'data/used.txt': 'referenced data\n',
+          'alternate.tex': '\\documentclass{alternate}\n',
+          'alternate.cls': '% unrelated document class\n',
+          'vendor/paper.cls': '% shadowed duplicate document class\n',
+          'sections/unused.tex': 'unreferenced section\n',
+          'review.txt': 'private review notes\n',
+          'source.zip': 'unrelated archive\n',
+          'main.vtc': 'unrelated file sharing the main basename\n',
+      }
+      for filename, content in files.items():
+        with open(
+            path.join(input_dir, filename), 'w', encoding='utf-8'
+        ) as file_obj:
+          file_obj.write(content)
+
+      arxiv_latex_cleaner.run_arxiv_cleaner({
+          'input_folder': input_dir,
+          'main_tex': 'main.tex',
+          'images_allowlist': {},
+          'resize_images': False,
+          'im_size': 500,
+          'compress_pdf': False,
+          'pdf_im_resolution': 500,
+          'commands_to_delete': [],
+          'commands_only_to_delete': [],
+          'environments_to_delete': [],
+          'if_exceptions': [],
+          'use_external_tikz': None,
+          'keep_bib': True,
+      })
+
+      output_files = set(
+          arxiv_latex_cleaner._list_all_files(input_dir + '_arXiv')
+      )
+      self.assertSetEqual(
+          output_files,
+          {
+              'main.tex',
+              'sections/body.tex',
+              'paper.cls',
+              'refs.bst',
+              'sources.bib',
+              'main.bbl',
+              'data/used.txt',
+          },
+      )
+
   def tearDown(self):
-    shutil.rmtree(self.out_path)
+    if path.isdir(self.out_path):
+      shutil.rmtree(self.out_path)
     super(IntegrationTests, self).tearDown()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This PR improves the generation of arXiv-ready source archives for projects
that contain multiple papers or unrelated root-level files.

It:

- adds a `--main_tex` option for selecting the paper entry point;
- retains only TeX files reachable from the selected entry point;
- copies only referenced root-level and nested dependencies;
- resolves ambiguous unqualified figure references by preferring the
  shallowest matching path;
- removes comments from retained `.bib` and `.bbl` files; and
- documents the new option and adds regression tests.

## Motivation

The cleaner currently treats every root-level TeX and non-TeX file as part of
the submission. For repositories containing multiple papers, backups, review
artifacts, or other private files, this can include unrelated content in the
generated arXiv directory.

In addition, comments are removed from TeX sources but can remain in copied
bibliography files. Those comments may contain notes that should not be included
in a public arXiv submission.

The new option allows users to select an explicit entry point:

```bash
arxiv_latex_cleaner /path/to/latex --main_tex main.tex
```

When `--main_tex` is not supplied, the existing behavior is preserved for
backward compatibility.

## Testing

- Ran the complete unit and integration test suite: 102 tests passed.
- Verified that the generated archive excludes unrelated root files,
  alternative TeX entry points, private notes, and shadowed figure files.
- Verified that referenced TeX, class, bibliography, data, and figure files are
  retained.
- Verified that escaped percent signs in bibliography contents are preserved
  while comments are removed.
- Cleaned and successfully compiled a multi-file, 28-page LaTeX project using
  the new option.
