### PR TITLE
feat: remove AI coding agent config files before arXiv submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ python setup.py install
 #### Privacy-oriented
 
 *   Removes all auxiliary files (`.aux`, `.log`, `.out`, etc.).
+*   Removes AI coding agent config/instruction files so they do not leak into
+    the arXiv source (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`,
+    `.windsurfrules`, `.claude/`, `.cursor/`, `.github/copilot-instructions.md`,
+    and many others). Pass `--keep_agent_files` to keep them.
 *   Removes all comments from your code (yes, those are visible on arXiv and you
     do not want them to be). These also include `\begin{comment}\end{comment}`,
     `\iffalse\fi`, and `\if0\fi` environments.
@@ -125,7 +129,7 @@ usage: arxiv_latex_cleaner@v1.0.11 [-h] [--resize_images] [--im_size IM_SIZE]
                                    [--compress_pdf]
                                    [--pdf_im_resolution PDF_IM_RESOLUTION]
                                    [--images_allowlist IMAGES_ALLOWLIST]
-                                   [--keep_bib]
+                                   [--keep_bib] [--keep_agent_files]
                                    [--commands_to_delete COMMANDS_TO_DELETE [COMMANDS_TO_DELETE ...]]
                                    [--commands_only_to_delete COMMANDS_ONLY_TO_DELETE [COMMANDS_ONLY_TO_DELETE ...]]
                                    [--environments_to_delete ENVIRONMENTS_TO_DELETE [ENVIRONMENTS_TO_DELETE ...]]
@@ -161,6 +165,10 @@ optional arguments:
                         --pdf_im_resolution, respectively. Format is a
                         dictionary as: '{"path/to/im.jpg": 1000}'
   --keep_bib            Avoid deleting the *.bib files.
+  --keep_agent_files    Avoid deleting AI coding agent config/instruction files
+                        (e.g. CLAUDE.md, AGENTS.md, GEMINI.md, .cursor/,
+                        .github/copilot-instructions.md). By default these are
+                        removed so they do not leak into the arXiv source.
   --commands_to_delete COMMANDS_TO_DELETE [COMMANDS_TO_DELETE ...]
                         LaTeX commands that will be deleted. Useful for e.g.
                         user-defined \todo commands. For example, to delete

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -90,6 +90,17 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--keep_agent_files",
+    action="store_true",
+    help=(
+        "Avoid deleting AI coding agent config/instruction files (e.g. "
+        "CLAUDE.md, AGENTS.md, GEMINI.md, .cursor/, .github/copilot-"
+        "instructions.md). By default these are removed so they do not leak "
+        "into the arXiv source."
+    ),
+)
+
+PARSER.add_argument(
     "--commands_to_delete",
     nargs="+",
     default=[],

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -34,6 +34,84 @@ PDF_RESIZE_COMMAND = (
 )
 MAX_FILENAME_LENGTH = 120
 
+# Files and directories written by AI coding agents/assistants (Claude Code,
+# OpenAI Codex, GitHub Copilot, Cursor, Gemini CLI, and others). They hold
+# instructions, memory, rules, and local tool config that should never end up
+# in an arXiv source bundle. Patterns are matched against POSIX-style relative
+# paths, so they cover both the project root and any subdirectory. Only tool-
+# specific names are included; generic names a human might legitimately use
+# (e.g. CONVENTIONS.md, memory-bank/) are deliberately left out to avoid
+# deleting real paper sources.
+AGENT_FILES_TO_DELETE = [
+    # Cross-tool standard instruction files (AGENTS.md / AGENT.md).
+    r'(?:^|/)AGENTS?\.md$',
+    r'(?:^|/)AGENTS\.override\.md$',
+    # Anthropic Claude / Claude Code.
+    r'(?:^|/)CLAUDE\.md$',
+    r'(?:^|/)CLAUDE\.local\.md$',
+    r'(?:^|/)\.claude/',
+    r'(?:^|/)\.mcp\.json$',
+    # OpenAI Codex.
+    r'(?:^|/)\.codex/',
+    # GitHub Copilot.
+    r'(?:^|/)\.github/copilot-instructions\.md$',
+    r'(?:^|/)\.github/instructions/',
+    r'(?:^|/)\.github/prompts/',
+    r'(?:^|/)\.github/chatmodes/',
+    # Cursor.
+    r'(?:^|/)\.cursorrules$',
+    r'(?:^|/)\.cursor/',
+    r'(?:^|/)\.cursorignore$',
+    r'(?:^|/)\.cursorindexingignore$',
+    # Windsurf / Codeium / Devin.
+    r'(?:^|/)\.windsurfrules$',
+    r'(?:^|/)\.windsurf/',
+    r'(?:^|/)\.devin/',
+    r'(?:^|/)\.codeiumignore$',
+    # Google Gemini CLI / Code Assist.
+    r'(?:^|/)GEMINI\.md$',
+    r'(?:^|/)\.gemini/',
+    r'(?:^|/)\.aiexclude$',
+    # Continue.dev.
+    r'(?:^|/)\.continue/',
+    r'(?:^|/)\.continuerules$',
+    # Cline.
+    r'(?:^|/)\.clinerules(?:$|/)',
+    r'(?:^|/)\.clineignore$',
+    # Roo Code.
+    r'(?:^|/)\.roo/',
+    r'(?:^|/)\.roorules',
+    r'(?:^|/)\.rooignore$',
+    # Aider (config, history, and cache files all start with '.aider').
+    r'(?:^|/)\.aider',
+    # Zed.
+    r'(?:^|/)\.rules$',
+    # JetBrains AI Assistant / Junie.
+    r'(?:^|/)\.aiassistant/',
+    r'(?:^|/)\.junie/',
+    r'(?:^|/)\.aiignore$',
+    r'(?:^|/)\.noai$',
+    # Amazon Q Developer / Kiro.
+    r'(?:^|/)\.amazonq/',
+    r'(?:^|/)\.kiro/',
+    # Augment Code.
+    r'(?:^|/)\.augment/',
+    r'(?:^|/)\.augment-guidelines$',
+    # OpenHands.
+    r'(?:^|/)\.openhands/',
+    r'(?:^|/)\.openhands_instructions$',
+    # Sourcegraph Cody.
+    r'(?:^|/)\.sourcegraph/',
+    r'(?:^|/)\.cody/',
+    # Trae, Qodo, Goose, Warp, Tabnine.
+    r'(?:^|/)\.trae/',
+    r'(?:^|/)\.qodo/',
+    r'(?:^|/)\.goose/',
+    r'(?:^|/)\.goosehints$',
+    r'(?:^|/)WARP\.md$',
+    r'(?:^|/)\.tabnine/',
+]
+
 # Fix for Windows: Even if '\' (os.sep) is the standard way of making paths on
 # Windows, it interferes with regular expressions. We just change os.sep to '/'
 # and os.path.join to a version using '/' as Windows will handle it the right
@@ -927,6 +1005,9 @@ def run_arxiv_cleaner(parameters):
 
   if not parameters['keep_bib']:
     files_to_delete.append(r'\.bib$')
+
+  if not parameters.get('keep_agent_files', False):
+    files_to_delete += AGENT_FILES_TO_DELETE
 
   parameters.update({
       'to_delete': files_to_delete,

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -15,6 +15,7 @@
 
 from os import path
 import shutil
+import tempfile
 import unittest
 from absl.testing import parameterized
 from arxiv_latex_cleaner import arxiv_latex_cleaner
@@ -998,6 +999,85 @@ class IntegrationTests(parameterized.TestCase):
   def tearDown(self):
     shutil.rmtree(self.out_path)
     super(IntegrationTests, self).tearDown()
+
+
+class AgentFileTests(parameterized.TestCase):
+  """Checks that AI coding agent config files are stripped from the output."""
+
+  # A representative sample of files created by AI coding agents that should
+  # never leak into an arXiv source bundle.
+  AGENT_FILES = [
+      'CLAUDE.md',
+      'CLAUDE.local.md',
+      'AGENTS.md',
+      'AGENT.md',
+      'GEMINI.md',
+      'WARP.md',
+      '.cursorrules',
+      '.windsurfrules',
+      '.mcp.json',
+      '.claude/settings.json',
+      '.claude/commands/foo.md',
+      '.cursor/rules/style.mdc',
+      '.gemini/settings.json',
+      '.codex/config.toml',
+      '.aider.chat.history.md',
+      '.github/copilot-instructions.md',
+  ]
+
+  def setUp(self):
+    super(AgentFileTests, self).setUp()
+    self.in_path = tempfile.mkdtemp()
+    self.out_path = self.in_path + '_arXiv'
+
+  def _populate_input(self):
+    # A minimal but valid paper that references nothing external.
+    with open(path.join(self.in_path, 'main.tex'), 'w') as f:
+      f.write('\\documentclass{article}\n\\begin{document}\nHi.\n'
+              '\\end{document}\n')
+    for rel_path in self.AGENT_FILES:
+      full_path = path.join(self.in_path, rel_path)
+      arxiv_latex_cleaner._create_dir_if_not_exists(path.dirname(full_path))
+      with open(full_path, 'w') as f:
+        f.write('agent instructions\n')
+
+  def _run(self, keep_agent_files):
+    arxiv_latex_cleaner.run_arxiv_cleaner({
+        'input_folder': self.in_path,
+        'images_allowlist': {},
+        'resize_images': False,
+        'im_size': 500,
+        'compress_pdf': False,
+        'pdf_im_resolution': 500,
+        'commands_to_delete': [],
+        'keep_bib': False,
+        'keep_agent_files': keep_agent_files,
+    })
+    return set(arxiv_latex_cleaner._list_all_files(self.out_path))
+
+  def test_agent_files_are_removed_by_default(self):
+    self._populate_input()
+    out_files = self._run(keep_agent_files=False)
+    self.assertIn('main.tex', out_files)
+    for rel_path in self.AGENT_FILES:
+      self.assertNotIn(
+          rel_path,
+          out_files,
+          '{:s} should have been removed.'.format(rel_path),
+      )
+
+  def test_agent_files_are_kept_with_flag(self):
+    self._populate_input()
+    out_files = self._run(keep_agent_files=True)
+    # Root-level files are always copied; with the opt-out they must survive.
+    self.assertIn('CLAUDE.md', out_files)
+    self.assertIn('AGENTS.md', out_files)
+
+  def tearDown(self):
+    shutil.rmtree(self.in_path, ignore_errors=True)
+    shutil.rmtree(self.out_path, ignore_errors=True)
+    super(AgentFileTests, self).tearDown()
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
## Summary

Adds removal of AI coding agent config/instruction files to the cleaner, so files left behind by tools like Claude Code, Codex, Copilot, Cursor, and Gemini CLI don't leak into the arXiv source bundle.

Enabled **by default**, consistent with the existing removal of `.gitignore`, `.DS_Store`, and `.idea`. A new `--keep_agent_files` flag opts out.

## Motivation

Researchers increasingly work in repos containing AI agent instruction/memory/rules files (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.claude/`, ...). These are private working notes and should not be published in the arXiv source, but the cleaner previously copied root-level files like `CLAUDE.md` and `AGENTS.md` straight through.

## What's covered

A curated deny-list of tool-specific names (matched against POSIX-style relative paths, so both root and subdirectories):

- **Cross-tool standard:** `AGENTS.md`, `AGENT.md`, `AGENTS.override.md`
- **Claude Code:** `CLAUDE.md`, `CLAUDE.local.md`, `.claude/`, `.mcp.json`
- **Codex:** `.codex/` · **Copilot:** `.github/copilot-instructions.md`, `.github/instructions|prompts|chatmodes/`
- **Cursor:** `.cursorrules`, `.cursor/`, `.cursorignore` · **Windsurf/Codeium:** `.windsurfrules`, `.windsurf/`, `.devin/`
- **Gemini:** `GEMINI.md`, `.gemini/`, `.aiexclude` · **Continue:** `.continue/`, `.continuerules`
- **Cline/Roo:** `.clinerules`, `.roo/` · **Aider:** `.aider*` · **Zed:** `.rules`
- Plus JetBrains Junie, Amazon Q/Kiro, Augment, OpenHands, Cody, Trae, Qodo, Goose, Warp, Tabnine

Generic names a human might legitimately use (`CONVENTIONS.md`, `memory-bank/`) are **deliberately excluded** to avoid deleting real paper sources.

## Testing

- Added `AgentFileTests` covering default removal and the `--keep_agent_files` opt-out.
- Full suite: **102 passed** (was 100).
- Manual CLI smoke test: default run strips all agent files while keeping `main.tex`/other sources; `--keep_agent_files` preserves them.

## Docs

README updated (Privacy-oriented feature list + usage block) and CLI `--help` text added.
