### PR TITLE
add --merge_tex_files option to merge .tex files into one (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ There is a 50MB limit on arXiv submissions, so to make it fit:
     `images_allowlist`.
 *   Optionally converts PNG images to JPG format to reduce file size.
 
+#### Merging the TeX files into a single file
+
+Sometimes it is useful to submit a single TeX file instead of the whole file
+structure, similar to [`latexpand`](https://ctan.org/pkg/latexpand). With
+`--merge_tex_files`, the tool:
+
+*   Recursively replaces the `\input{...}` and `\include{...}` commands in the
+    root `.tex` files with the contents of the files they reference, and does
+    not copy the merged files to the output folder.
+*   Replaces `\include{...}` together with its implicit `\clearpage` commands,
+    so that the compiled document stays the same.
+*   Applies all the other cleaning steps as usual to the merged output. Note
+    that `\includeonly` is not supported.
+
 #### TikZ picture source code concealment
 
 To prevent the upload of tikzpicture source code or raw simulation data, this
@@ -125,7 +139,7 @@ usage: arxiv_latex_cleaner@v1.0.11 [-h] [--resize_images] [--im_size IM_SIZE]
                                    [--compress_pdf]
                                    [--pdf_im_resolution PDF_IM_RESOLUTION]
                                    [--images_allowlist IMAGES_ALLOWLIST]
-                                   [--keep_bib]
+                                   [--keep_bib] [--merge_tex_files]
                                    [--commands_to_delete COMMANDS_TO_DELETE [COMMANDS_TO_DELETE ...]]
                                    [--commands_only_to_delete COMMANDS_ONLY_TO_DELETE [COMMANDS_ONLY_TO_DELETE ...]]
                                    [--environments_to_delete ENVIRONMENTS_TO_DELETE [ENVIRONMENTS_TO_DELETE ...]]
@@ -161,6 +175,13 @@ optional arguments:
                         --pdf_im_resolution, respectively. Format is a
                         dictionary as: '{"path/to/im.jpg": 1000}'
   --keep_bib            Avoid deleting the *.bib files.
+  --merge_tex_files     Merge the TeX files into a single file, by
+                        recursively replacing the \input and \include
+                        commands in the root TeX files with the contents
+                        of the files they reference; \include is replaced
+                        together with its implicit \clearpage commands.
+                        The merged files are not copied to the output
+                        folder. Note that \includeonly is not supported.
   --commands_to_delete COMMANDS_TO_DELETE [COMMANDS_TO_DELETE ...]
                         LaTeX commands that will be deleted. Useful for e.g.
                         user-defined \todo commands. For example, to delete

--- a/arxiv_latex_cleaner/__main__.py
+++ b/arxiv_latex_cleaner/__main__.py
@@ -90,6 +90,19 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--merge_tex_files",
+    action="store_true",
+    help=(
+        "Merge the TeX files into a single file, by recursively replacing "
+        "the \\input and \\include commands in the root TeX files with the "
+        "contents of the files they reference; \\include is replaced "
+        "together with its implicit \\clearpage commands. The merged files "
+        "are not copied to the output folder. Note that \\includeonly is "
+        "not supported."
+    ),
+)
+
+PARSER.add_argument(
     "--commands_to_delete",
     nargs="+",
     default=[],

--- a/arxiv_latex_cleaner/arxiv_latex_cleaner.py
+++ b/arxiv_latex_cleaner/arxiv_latex_cleaner.py
@@ -831,6 +831,52 @@ def _add_root_tex_files(splits):
       splits['tex_to_copy'].append(fn)
 
 
+def _merge_tex_files(filename, tex_contents, merged_files=None):
+  """Returns the contents of 'filename' with the referenced files merged in.
+
+  Replaces the '\\input{*}' and '\\include{*}' commands with the contents of
+  the files they reference, recursively; an '\\include{*}' command is
+  replaced together with the implicit '\\clearpage' before and after the file
+  contents, as in 'latexpand'. A command is only replaced if the referenced
+  file is a key of 'tex_contents'; the '.tex' extension may be omitted in the
+  command. Unknown and circular references are left untouched. The names of
+  the replaced files are added to the set 'merged_files'.
+  """
+  if merged_files is None:
+    merged_files = set()
+
+  def merge_file(filename, open_files):
+    def replace_reference(match):
+      input_filename = match.group(2)
+      if input_filename.startswith('.' + os.sep):
+        input_filename = input_filename[2:]
+      if input_filename not in tex_contents:
+        input_filename += '.tex'
+      if input_filename not in tex_contents or input_filename in open_files:
+        return match.group(0)
+      merged_files.add(input_filename)
+      merged_content = merge_file(
+          input_filename, open_files | {input_filename}
+      )
+      # Removes the BOM potentially present at the beginning of the merged
+      # file, as it is only valid there and would end up in the middle of the
+      # merged output.
+      merged_content = merged_content.removeprefix('\ufeff')
+      if match.group(1) == 'include':
+        # '\include' implies a '\clearpage' before and after the file
+        # contents.
+        merged_content = '\\clearpage{}\n' + merged_content + '\\clearpage{}\n'
+      return merged_content
+
+    return regex.sub(
+        r'\\(input|include)[\s%]*\{[\s%]*([^\s%}]+)[\s%]*\}',
+        replace_reference,
+        tex_contents[filename],
+    )
+
+  return merge_file(filename, {filename})
+
+
 def _split_all_files(parameters):
   """Splits the files into types or location to know what to do with them."""
   file_splits = {
@@ -983,6 +1029,18 @@ def run_arxiv_cleaner(parameters):
 
     _keep_only_referenced_tex(tex_contents, splits)
     _add_root_tex_files(splits)
+
+    if parameters.get('merge_tex_files', False):
+      full_contents = {fn: '\n'.join(tex_contents[fn]) for fn in tex_contents}
+      merged_files = set()
+      for tex_file in splits['tex_in_root']:
+        logging.info('Merging referenced TeX files into file %s.', tex_file)
+        tex_contents[tex_file] = _merge_tex_files(
+            tex_file, full_contents, merged_files
+        ).split('\n')
+      splits['tex_to_copy'] = [
+          fn for fn in splits['tex_to_copy'] if fn not in merged_files
+      ]
 
     for tex_file in splits['tex_to_copy']:
       logging.info('Replacing patterns in file %s.', tex_file)

--- a/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
+++ b/arxiv_latex_cleaner/tests/arxiv_latex_cleaner_test.py
@@ -677,6 +677,143 @@ class UnitTests(parameterized.TestCase):
         true_output,
     )
 
+  @parameterized.named_parameters(
+      {
+          'testcase_name': 'no_input',
+          'tex_contents': {'main.tex': 'Foo\nFoo2\n'},
+          'true_output': 'Foo\nFoo2\n',
+          'true_merged_files': set(),
+      },
+      {
+          'testcase_name': 'input_with_extension',
+          'tex_contents': {
+              'main.tex': 'A\n\\input{section.tex}\nB\n',
+              'section.tex': 'C\nD\n',
+          },
+          'true_output': 'A\nC\nD\n\nB\n',
+          'true_merged_files': {'section.tex'},
+      },
+      {
+          'testcase_name': 'input_without_extension',
+          'tex_contents': {
+              'main.tex': 'A\n\\input{section}\nB\n',
+              'section.tex': 'C\nD\n',
+          },
+          'true_output': 'A\nC\nD\n\nB\n',
+          'true_merged_files': {'section.tex'},
+      },
+      {
+          'testcase_name': 'input_tikz',
+          'tex_contents': {
+              'main.tex': 'A\n\\input{figures/figure.tikz}\nB\n',
+              'figures/figure.tikz': 'C\n',
+          },
+          'true_output': 'A\nC\n\nB\n',
+          'true_merged_files': {'figures/figure.tikz'},
+      },
+      {
+          'testcase_name': 'input_path_starting_with_dot',
+          'tex_contents': {
+              'main.tex': 'A\n\\input{./figures/section.tex}\nB\n',
+              'figures/section.tex': 'C\n',
+          },
+          'true_output': 'A\nC\n\nB\n',
+          'true_merged_files': {'figures/section.tex'},
+      },
+      {
+          'testcase_name': 'input_recursive',
+          'tex_contents': {
+              'main.tex': 'A\n\\input{section.tex}\nB\n',
+              'section.tex': 'C\n\\input{subsection.tex}\nD\n',
+              'subsection.tex': 'E\n',
+          },
+          'true_output': 'A\nC\nE\n\nD\n\nB\n',
+          'true_merged_files': {'section.tex', 'subsection.tex'},
+      },
+      {
+          'testcase_name': 'input_twice',
+          'tex_contents': {
+              'main.tex': '\\input{table.tex}\n\\input{table.tex}\n',
+              'table.tex': 'C\n',
+          },
+          'true_output': 'C\n\nC\n\n',
+          'true_merged_files': {'table.tex'},
+      },
+      {
+          'testcase_name': 'input_with_comments',
+          'tex_contents': {
+              'main.tex': 'A\n\\input{%\n  section.tex%\n}\nB\n',
+              'section.tex': 'C\n',
+          },
+          'true_output': 'A\nC\n\nB\n',
+          'true_merged_files': {'section.tex'},
+      },
+      {
+          'testcase_name': 'input_with_bom',
+          'tex_contents': {
+              'main.tex': 'A\n\\input{section.tex}\nB\n',
+              'section.tex': '\ufeffC\n',
+          },
+          'true_output': 'A\nC\n\nB\n',
+          'true_merged_files': {'section.tex'},
+      },
+      {
+          'testcase_name': 'include',
+          'tex_contents': {
+              'main.tex': 'A\n\\include{chapter}\nB\n',
+              'chapter.tex': 'C\n',
+          },
+          'true_output': 'A\n\\clearpage{}\nC\n\\clearpage{}\n\nB\n',
+          'true_merged_files': {'chapter.tex'},
+      },
+      {
+          'testcase_name': 'include_recursive_input',
+          'tex_contents': {
+              'main.tex': 'A\n\\include{chapter}\nB\n',
+              'chapter.tex': 'C\n\\input{section.tex}\nD\n',
+              'section.tex': 'E\n',
+          },
+          'true_output': 'A\n\\clearpage{}\nC\nE\n\nD\n\\clearpage{}\n\nB\n',
+          'true_merged_files': {'chapter.tex', 'section.tex'},
+      },
+      {
+          'testcase_name': 'input_not_found_untouched',
+          'tex_contents': {'main.tex': 'A\n\\input{missing.tex}\nB\n'},
+          'true_output': 'A\n\\input{missing.tex}\nB\n',
+          'true_merged_files': set(),
+      },
+      {
+          'testcase_name': 'include_not_found_untouched',
+          'tex_contents': {'main.tex': 'A\n\\include{missing}\nB\n'},
+          'true_output': 'A\n\\include{missing}\nB\n',
+          'true_merged_files': set(),
+      },
+      {
+          'testcase_name': 'input_circular_untouched',
+          'tex_contents': {'main.tex': 'A\n\\input{main.tex}\nB\n'},
+          'true_output': 'A\n\\input{main.tex}\nB\n',
+          'true_merged_files': set(),
+      },
+      {
+          'testcase_name': 'includegraphics_untouched',
+          'tex_contents': {
+              'main.tex': 'A\n\\includegraphics{figures/figure.tikz}\nB\n',
+              'figures/figure.tikz': 'C\n',
+          },
+          'true_output': 'A\n\\includegraphics{figures/figure.tikz}\nB\n',
+          'true_merged_files': set(),
+      },
+  )
+  def test_merge_tex_files(self, tex_contents, true_output, true_merged_files):
+    merged_files = set()
+    self.assertEqual(
+        arxiv_latex_cleaner._merge_tex_files(
+            'main.tex', tex_contents, merged_files
+        ),
+        true_output,
+    )
+    self.assertSetEqual(merged_files, true_merged_files)
+
   @parameterized.named_parameters(*make_search_reference_tests())
   def test_search_reference_weak(
       self, filenames, contents, strict, true_outputs
@@ -994,6 +1131,70 @@ class IntegrationTests(parameterized.TestCase):
         self._compare_files(
             path.join(self.out_path, f1), path.join(out_path_true, f1)
         )
+
+  @parameterized.named_parameters(
+      {'testcase_name': 'from_dir', 'input_dir': 'test_data/tex'},
+      {'testcase_name': 'from_zip', 'input_dir': 'test_data/tex.zip'},
+  )
+  def test_merge_tex_files(self, input_dir):
+    out_path_true = 'test_data/tex_arXiv_true'
+    merged_files_true = [
+        'figures/figure_included.tex',
+        'figures/figure_included.tikz',
+    ]
+
+    # Make sure the folder does not exist, since we erase it in the test.
+    if path.isdir(self.out_path):
+      raise RuntimeError(
+          'The folder {:s} should not exist.'.format(self.out_path)
+      )
+
+    arxiv_latex_cleaner.run_arxiv_cleaner({
+        'input_folder': input_dir,
+        'images_allowlist': {
+            'images/im2_included.jpg': 200,
+            'images/im3_included.png': 400,
+        },
+        'resize_images': True,
+        'im_size': 100,
+        'compress_pdf': False,
+        'pdf_im_resolution': 500,
+        'commands_to_delete': ['mytodo'],
+        'commands_only_to_delete': ['red'],
+        'if_exceptions': ['iffalt'],
+        'environments_to_delete': ['mynote'],
+        'use_external_tikz': 'ext_tikz',
+        'keep_bib': False,
+        'merge_tex_files': True,
+    })
+
+    # Checks the merged files are not copied to the output folder, and that the
+    # set of files is otherwise the same as without merging.
+    out_files = set(arxiv_latex_cleaner._list_all_files(self.out_path))
+    out_files_true = set(
+        arxiv_latex_cleaner._list_all_files(out_path_true)
+    ) - set(merged_files_true)
+    self.assertSetEqual(out_files, out_files_true)
+
+    # Compares the contents of each file but the root file against the true
+    # value.
+    for f1 in out_files:
+      if f1 != 'main.tex':
+        self._compare_files(
+            path.join(self.out_path, f1), path.join(out_path_true, f1)
+        )
+
+    # Checks the root file contains the contents of the merged files, and no
+    # \input commands anymore.
+    with open(path.join(self.out_path, 'main.tex'), encoding='utf-8') as f:
+      main_content = f.read()
+    self.assertNotIn('\\input{', main_content)
+    self.assertNotIn('\\include{', main_content)
+    for merged_file in merged_files_true:
+      with open(path.join(out_path_true, merged_file), encoding='utf-8') as f:
+        # The BOM at the beginning of a file is stripped when it is merged.
+        merged_content_true = f.read().removeprefix('\ufeff')
+      self.assertIn(merged_content_true, main_content)
 
   def tearDown(self):
     shutil.rmtree(self.out_path)


### PR DESCRIPTION
Adds an opt-in `--merge_tex_files` flag that merges the cleaned submission into a single .tex file per root file (closes #65).

- Recursively replaces `\input{...}` and `\include{...}` in the root .tex files with the contents of the referenced files (extension may be omitted); merged files are not copied to the output folder.
- `\include` is replaced together with its implicit `\clearpage` before and after, as in latexpand, so the compiled document is unchanged. `\includeonly` is not supported.
- Unknown and circular references are left untouched. Merging runs after comment removal, so commented-out `\input`s are never merged. All other cleaning steps apply to the merged output as usual.
- Includes parameterized unit tests and dir/zip integration tests. While I don't think that new test data required, I could be missing edge-cases. 
- README updated.